### PR TITLE
Overloaded primitive operations require a type annotation.

### DIFF
--- a/src/bin/mo.rs
+++ b/src/bin/mo.rs
@@ -119,8 +119,8 @@ fn main() -> OurResult<()> {
         CliCommand::Eval { input, step_limit } => {
             let mut limits = Limits::none();
             match step_limit {
-                None => {},
-                Some(limit) => limits.step(limit)
+                None => {}
+                Some(limit) => limits.step(limit),
             };
             let v = motoko::vm::eval_limit(&input, &limits);
             println!("final value: {:?}", v)

--- a/src/lib/check.rs
+++ b/src/lib/check.rs
@@ -1,7 +1,7 @@
 use crate::ast::Prog;
 use crate::format::{format_one_line, format_pretty};
 use crate::lexer::{create_token_tree, TokenTree};
-use crate::vm_types::Limits;
+use crate::vm_types::{Interruption, Limits};
 
 pub fn parse(input: &str) -> Result<Prog, ()> {
     // crate::parser::ExpParser::new().parse(input).map_err(|_| ())
@@ -46,10 +46,23 @@ pub fn assert_roundtrip(input: &str) {
 
 pub fn assert_vm_eval(input_prog: &str, expected_result: &str) {
     println!(
-        "\nassert_vm_run(\"{}\", \"{}\")",
+        "\nassert_vm_eval(\"{}\", \"{}\")",
         input_prog, expected_result
     );
     let v1 = crate::vm::eval(input_prog).unwrap();
     let v2 = crate::vm::eval(expected_result).unwrap();
     assert_eq!(v1, v2)
+}
+
+pub fn assert_vm_interruption(input_prog: &str, expected_interruption: &Interruption) {
+    println!(
+        "\nassert_vm_interruption(\"{:?}\", \"{:?}\")",
+        input_prog, expected_interruption
+    );
+    match crate::vm::eval_(input_prog) {
+        Err(ref i) => assert_eq!(i, expected_interruption),
+        Ok(ref v) => {
+            unreachable!("expected Err({:?}), not Ok({:?})", expected_interruption, v)
+        }
+    }
 }

--- a/src/lib/parser.lalrpop
+++ b/src/lib/parser.lalrpop
@@ -276,7 +276,9 @@ ExpBin_<B>: Exp_ = {
 
 ExpBin<B>: Exp = {
     <e1:ExpBin_<B>> "+" <e2:ExpBin1_<B>> => Exp::Bin(e1, BinOp::Add, e2),
+    <e1:ExpBin_<B>> "+%" <e2:ExpBin1_<B>> => Exp::Bin(e1, BinOp::WAdd, e2),
     <e1:ExpBin_<B>> "-" <e2:ExpBin1_<B>> => Exp::Bin(e1, BinOp::Sub, e2),
+    <e:ExpBin_<B>> ":" <t:Type_> => Exp::Annot(e, t),
     ExpBin1<B>,
 }
 

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -1,7 +1,7 @@
 use im_rc::{HashMap, Vector};
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Dec, Exp_, Id as Identifier, Type};
+use crate::ast::{Dec, Exp_, Id as Identifier, PrimType, Type};
 use crate::value::Value;
 
 /// Or maybe a string?
@@ -29,7 +29,7 @@ pub enum Cont {
 
 pub mod stack {
     use super::{Cont, Env, Vector};
-    use crate::ast::{BinOp, Cases, Exp, Exp_, Id_, Pat, UnOp, PrimType, Type};
+    use crate::ast::{BinOp, Cases, Exp, Exp_, Id_, Pat, PrimType, Type, Type_, UnOp};
     use crate::value::Value;
     use serde::{Deserialize, Serialize};
 
@@ -47,7 +47,7 @@ pub mod stack {
         Do,
         Block,
         Tuple(Vector<Value>, Vector<Exp>),
-        Annot(Type),
+        Annot(Type_),
     }
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Frame {
@@ -131,7 +131,7 @@ pub struct Limits {
     pub send: Option<usize>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Limit {
     Step,
     Stack,
@@ -149,7 +149,7 @@ pub struct Step {
 }
 
 // interruptions are events that prevent steppping from progressing.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Interruption {
     TypeMismatch,
     NoMatchingCase,
@@ -159,7 +159,8 @@ pub enum Interruption {
     Limit(Limit),
     DivideByZero,
     Done(Value),
-    Unknown
+    AmbiguousOperation,
+    Unknown,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -1,7 +1,7 @@
 use im_rc::{HashMap, Vector};
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Dec, Exp_, Id as Identifier};
+use crate::ast::{Dec, Exp_, Id as Identifier, Type};
 use crate::value::Value;
 
 /// Or maybe a string?
@@ -27,14 +27,9 @@ pub enum Cont {
     Value(Value),
 }
 
-/// Some(Value) exists if and only if the continuation is fully evaluated.
-pub fn cont_is_value(_env: &Env, _c: Cont) -> Option<Value> {
-    unimplemented!()
-}
-
 pub mod stack {
     use super::{Cont, Env, Vector};
-    use crate::ast::{BinOp, Cases, Exp, Exp_, Id_, Pat, UnOp};
+    use crate::ast::{BinOp, Cases, Exp, Exp_, Id_, Pat, UnOp, PrimType, Type};
     use crate::value::Value;
     use serde::{Deserialize, Serialize};
 
@@ -52,11 +47,13 @@ pub mod stack {
         Do,
         Block,
         Tuple(Vector<Value>, Vector<Exp>),
+        Annot(Type),
     }
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Frame {
         pub env: Env,
         pub cont: FrameCont,
+        pub cont_prim_type: Option<PrimType>,
     }
     pub type Frames = im_rc::Vector<Frame>;
 }
@@ -93,6 +90,9 @@ pub struct Core {
     pub stack: Stack,
     pub env: Env,
     pub cont: Cont,
+    /// `Some(t)` when evaluating under an annotation of type `t`.
+    /// (`e : Nat8`  makes `Nat8` the `cont_prim_type` for `e`)
+    pub cont_prim_type: Option<PrimType>,
     pub counts: Counts,
 }
 

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -44,5 +44,6 @@ fn test_tuples() {
 fn test_prim_ops() {
     assert_("255 + 1 : Nat", "256");
     assert_("255 +% 1 : Nat8", "0");
+    assert_("(255 +% 1) +% (255 +% 1) : Nat8", "0");
     assert_x("255 +% 1", &Interruption::AmbiguousOperation);
 }

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -1,4 +1,6 @@
 use motoko::check::assert_vm_eval as assert_;
+use motoko::check::assert_vm_interruption as assert_x;
+use motoko::vm_types::Interruption;
 
 fn assert_is_value(v: &str) {
     assert_(v, v)
@@ -36,4 +38,11 @@ fn test_switch() {
 fn test_tuples() {
     assert_("(1, 2, 3)", "(1, 2, 3)");
     assert_("(1 + 1, 2 + 2, 3 + 3)", "(2, 4, 6)");
+}
+
+#[test]
+fn test_prim_ops() {
+    assert_("255 + 1 : Nat", "256");
+    assert_("255 +% 1 : Nat8", "0");
+    assert_x("255 +% 1", &Interruption::AmbiguousOperation);
 }


### PR DESCRIPTION
Today Claudio raised some issues about the VM trying to be faithful to Motoko without the virtue of static types.

This was one example that presents a challenge (output from the interperter):

```
> (255 +% 1) : Nat8
  ;
0 : Nat8
> (255 +% 1) : Nat16
  ;
256 : Nat16
```

Notice how wrapped addition depends on the ambient type being produced.

So how do we distinguish how wrapped addition, and other operations that depend on the size, are supposed to operate without the static types that informs these decisions?

This PR gives a partial solution, where the programmer is obliged to write annotations to disambiguate each such operation, otherwise they get a runtime error about the ambiguity.

The solution works for `Nat` versus `Nat8` (generalizable to other prim types too), with a regression test to demonstrate.

This solution is satisfying in its adherence to the compiler's behavior regarding the role of static type information, but it's dissatisfying in that it doesn't actually propagate type information the way that a bidirectional type checker would do so, and thus requires a more simple-minded annotation in every subexpression with overloaded primitives (though not every operation therein).

I find this satisfying for the short term, but I'm interested in others' views too.

[See the test programs.](https://github.com/dfinity/motoko.rs/pull/17/files#diff-993b69288a03530405f6ba8df03da3bf1402c1a5cfaa54feb0c89dde4ae64e71R44)