### PR TITLE
Retain line/column numbers after filtering comments

### DIFF
--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -283,3 +283,20 @@ fn test_block_comments() {
     assert_to("#/**/a", "#a");
     assert_to("/*(*/", "");
 }
+
+#[test]
+fn test_source_comments() {
+    use motoko::ast::{Dec, Exp, Loc, Source};
+    use motoko::check::parse;
+    let ast = parse("//\n/*a*/a").unwrap();
+    println!("{:?}", ast);
+    let expected = Loc(
+        Box::new(Dec::Exp(Exp::Var("a".to_string()))),
+        Source::Known {
+            line: 2,
+            col: 6,
+            span: 8..9,
+        },
+    );
+    assert!(ast.vec[0] == expected, "Location mismatch");
+}


### PR DESCRIPTION
Replaces comments with corresponding whitespace to retain correct line/column/span values. 