### PR TITLE
Core tracks source of current contination.

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -34,24 +34,31 @@ pub enum Source {
         col: usize,
     },
     Unknown,
+    Evaluation,
+    CoreInit,
 }
 
 impl Source {
     pub fn expand(&self, other: &Source) -> Source {
+        use Source::*;
         match (self, other) {
-            (Source::Unknown, Source::Unknown) => Source::Unknown,
+            (Unknown, Unknown) => Source::Unknown,
             (
-                Source::Known { span, line, col },
-                Source::Known {
+                Known { span, line, col },
+                Known {
                     span: other_span, ..
                 },
-            ) => Source::Known {
+            ) => Known {
                 span: span.start..other_span.end,
                 line: *line,
                 col: *col,
             },
-            (_, Source::Unknown) => self.clone(),
-            (Source::Unknown, _) => other.clone(),
+            (_, Unknown) => self.clone(),
+            (Unknown, _) => other.clone(),
+            (CoreInit, _) => todo!(),
+            (_, CoreInit) => todo!(),
+            (Evaluation, _) => todo!(),
+            (_, Evaluation) => todo!(),
         }
     }
 }
@@ -60,8 +67,12 @@ impl std::fmt::Display for Source {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             //Source::Known { line, col, .. } => write!(f, "{}:{}", line, col),
-            Source::Known { span, line, col } => write!(f, "{}..{} @ {}:{}", span.start, span.end, line, col),
+            Source::Known { span, line, col } => {
+                write!(f, "{}..{} @ {}:{}", span.start, span.end, line, col)
+            }
             Source::Unknown => write!(f, "(unknown source)"),
+            Source::Evaluation => write!(f, "(evaluation)"),
+            Source::CoreInit => write!(f, "(full program, via core init)"),
         }
     }
 }

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -216,6 +216,7 @@ fn switch(core: &mut Core, _limits: &Limits, v: Value, cases: Cases) -> Result<S
     for case in cases.vec.into_iter() {
         if let Some(env) = pattern_matches(&core.env, &*case.0.pat.0, &v) {
             core.env = env;
+            core.cont_source = case.0.exp.1.clone();
             core.cont = Cont::Exp_(case.0.exp);
             return Ok(Step {});
         }
@@ -232,6 +233,8 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
         let frame = core.stack.pop_front().unwrap();
         core.env = frame.env;
         core.cont_prim_type = frame.cont_prim_type;
+        // deciding _not_ to set core.cont_source to Evaluation,
+        // but instead keep original binary operation source info associated with result.  Seems more useful.
         match frame.cont {
             UnOp(un) => {
                 core.cont = Cont::Value(unop(un, v)?);

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -1,7 +1,7 @@
 use im_rc::{HashMap, Vector};
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Dec_, Exp_, Id as Identifier, PrimType};
+use crate::ast::{Dec_, Exp_, Id as Identifier, PrimType, Source};
 use crate::value::Value;
 
 /// Or maybe a string?
@@ -91,6 +91,7 @@ pub struct Core {
     pub stack: Stack,
     pub env: Env,
     pub cont: Cont,
+    pub cont_source: Source,
     /// `Some(t)` when evaluating under an annotation of type `t`.
     /// (`e : Nat8`  makes `Nat8` the `cont_prim_type` for `e`)
     pub cont_prim_type: Option<PrimType>,


### PR DESCRIPTION
- add field `cont_source` to `Core` structure.
- the `cont_source` changes when the Core changes "focus" within the source program to some subexpression within it.
- Cosmetic -- reverse representation order of stack, so that pretty printing looks more standard.