### PR TITLE
Remove unused counters, for now.

### DIFF
--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -41,10 +41,12 @@ pub fn core_init(prog: Prog) -> Core {
         cont_prim_type,
         counts: Counts {
             step: 0,
+            /*
             stack: 0,
             call: 0,
             alloc: 0,
             send: 0,
+             */
         },
     }
 }

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -74,10 +74,11 @@ pub type Store = HashMap<Pointer, Value>;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Counts {
     pub step: usize,
-    pub stack: usize,
+    /*
     pub call: usize,
     pub alloc: usize,
     pub send: usize,
+     */
 }
 
 /// Encapsulates VM state for "core Motoko code",


### PR DESCRIPTION
Nit:  In retrospect, it's confusing to include these fields when we do not use them or expose them.

They were temporarily useful for discussing with Ryan.  We can uncomment them once we use them.