### PR TITLE
Breakpoints.

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -26,13 +26,11 @@ impl<X> Node<X> {
     }
 }
 
+pub type Span = Range<usize>;
+
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Source {
-    Known {
-        span: Range<usize>,
-        line: usize,
-        col: usize,
-    },
+    Known { span: Span, line: usize, col: usize },
     Unknown,
     Evaluation,
     CoreInit,

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -37,6 +37,13 @@ pub enum Source {
 }
 
 impl Source {
+    pub fn span(&self) -> Option<Span> {
+        use Source::*;
+        match self {
+            Known { span, .. } => Some(span.clone()),
+            _ => None,
+        }
+    }
     pub fn expand(&self, other: &Source) -> Source {
         use Source::*;
         match (self, other) {

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -366,6 +366,7 @@ pub fn eval_limit(prog: &str, limits: &Limits) -> Result<Value, Interruption> {
     match s {
         Done(result) => Ok(result),
         Interruption(i) => Err(i),
+        Breakpoint(_) => todo!(),
     }
 }
 

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -3,7 +3,7 @@ use crate::ast_utils::Syntax;
 use crate::value::Value;
 use crate::vm_types::{
     stack::{Frame, FrameCont},
-    Cont, Core, Counts, Env, Error, Interruption, Limit, Limits, Local, Signal, Step,
+    Breakpoint, Cont, Core, Counts, Env, Error, Interruption, Limit, Limits, Local, Signal, Step,
 };
 use im_rc::{HashMap, Vector};
 use num_bigint::{BigInt, BigUint};
@@ -16,21 +16,20 @@ impl From<()> for Interruption {
 }
 
 impl Limits {
+    /// No limits.
     pub fn none() -> Limits {
         Limits {
+            breakpoints: vec![],
             step: None,
-            stack: None,
-            call: None,
-            alloc: None,
-            send: None,
         }
     }
+    /// Set step limit.
     pub fn step(&mut self, s: usize) {
         self.step = Some(s);
     }
 }
 
-pub fn core_init(prog: Prog) -> Core {
+fn core_init(prog: Prog) -> Core {
     let cont_prim_type: Option<PrimType> = None;
     Core {
         store: HashMap::new(),
@@ -300,7 +299,7 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
 }
 
 // To advance the core Motoko state by a single step.
-pub fn core_step(core: &mut Core, limits: &Limits) -> Result<Step, Interruption> {
+fn core_step(core: &mut Core, limits: &Limits) -> Result<Step, Interruption> {
     println!("# step {}", core.counts.step);
     println!(" - cont_source = {:?}", core.cont_source);
     println!(" - cont = {:?}", core.cont);
@@ -339,14 +338,43 @@ pub fn core_step(core: &mut Core, limits: &Limits) -> Result<Step, Interruption>
     }
 }
 
+impl Core {
+    /// New VM core for a given program.
+    pub fn new(prog: Prog) -> Self {
+        core_init(prog)
+    }
+
+    /// Step VM core, under some limits.
+    pub fn step(&mut self, limits: &Limits) -> Result<Step, Interruption> {
+        core_step(self, limits)
+    }
+}
+
 // For core Motoko state initializing local VM state.
-pub fn local_init(active: Core) -> Local {
+fn local_init(active: Core) -> Local {
     Local { active }
 }
 
+// Returns `Some(span)` if the limits include the breakpoint.
+fn check_for_breakpoint(local: &mut Local, limits: &Limits) -> Option<Breakpoint> {
+    let cont_span = &local.active.cont_source.span();
+    if let Some(span) = cont_span {
+        if limits.breakpoints.contains(span) {
+            Some(span.clone())
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
 // use ic-agent to do function calls.
-pub fn local_run(local: &mut Local, limits: &Limits) -> Result<Signal, Error> {
+fn local_run(local: &mut Local, limits: &Limits) -> Result<Signal, Error> {
     loop {
+        if let Some(break_span) = check_for_breakpoint(local, limits) {
+            return Ok(Signal::Breakpoint(break_span));
+        }
         match core_step(&mut local.active, limits) {
             Ok(_step) => { /* to do */ }
             Err(Interruption::Done(v)) => return Ok(Signal::Done(v)),
@@ -355,12 +383,22 @@ pub fn local_run(local: &mut Local, limits: &Limits) -> Result<Signal, Error> {
     }
 }
 
+impl Local {
+    /// New local VM instance for given `Core`.
+    pub fn new(core: Core) -> Self {
+        local_init(core)
+    }
+    /// Run the local VM (under some possible limits).
+    pub fn run(&mut self, limits: &Limits) -> Result<Signal, Error> {
+        local_run(self, limits)
+    }
+}
+
 /// Used for tests in check module.
 pub fn eval_limit(prog: &str, limits: &Limits) -> Result<Value, Interruption> {
     let p = crate::check::parse(&prog)?;
-    let c = core_init(p);
-    let mut l = local_init(c);
-    let s = local_run(&mut l, limits).map_err(|_| ())?;
+    let mut l = Local::new(Core::new(p));
+    let s = l.run(limits).map_err(|_| ())?;
     println!("final signal: {:?}", s);
     use crate::vm_types::Signal::*;
     match s {

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -99,9 +99,6 @@ pub struct Core {
     pub counts: Counts,
 }
 
-/// Set of active breakpoints.
-pub type Breakpoints = HashMap<Breakpoint, ()>;
-
 /// Encapsulates the VM state running Motoko code locally,
 /// as a script interacting with the internet computer from the
 /// outside of the IC.
@@ -115,7 +112,6 @@ pub struct Local {
     // to do
     // - one "active" Core.
     pub active: Core,
-    //pub breakpoints: Breakpoints,
     // - a DAG of inactive Cores, related to the active one.
     // - DAG is initially empty.
 }
@@ -131,11 +127,15 @@ pub struct Canister {
 // to interject some "slow interactivity" into its execution.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Limits {
+    pub breakpoints: Vec<Breakpoint>,
+
     pub step: Option<usize>,
+    /*
     pub stack: Option<usize>,
     pub call: Option<usize>,
     pub alloc: Option<usize>,
     pub send: Option<usize>,
+     */
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -158,6 +158,7 @@ pub struct Step {
 // interruptions are events that prevent steppping from progressing.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Interruption {
+    Done(Value),
     TypeMismatch,
     NoMatchingCase,
     ParseError,
@@ -165,7 +166,6 @@ pub enum Interruption {
     BlockedAwaiting,
     Limit(Limit),
     DivideByZero,
-    Done(Value),
     AmbiguousOperation,
     Unknown,
 }
@@ -173,8 +173,8 @@ pub enum Interruption {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Signal {
     Done(Value),
-    Interruption(Interruption),
     Breakpoint(Breakpoint),
+    Interruption(Interruption),
 }
 
 pub type Breakpoint = Span;

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -1,7 +1,7 @@
 use im_rc::{HashMap, Vector};
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Dec_, Exp_, Id as Identifier, PrimType, Source};
+use crate::ast::{Dec_, Exp_, Id as Identifier, PrimType, Source, Span};
 use crate::value::Value;
 
 /// Or maybe a string?
@@ -99,6 +99,9 @@ pub struct Core {
     pub counts: Counts,
 }
 
+/// Set of active breakpoints.
+pub type Breakpoints = HashMap<Breakpoint, ()>;
+
 /// Encapsulates the VM state running Motoko code locally,
 /// as a script interacting with the internet computer from the
 /// outside of the IC.
@@ -171,7 +174,10 @@ pub enum Interruption {
 pub enum Signal {
     Done(Value),
     Interruption(Interruption),
+    Breakpoint(Breakpoint),
 }
+
+pub type Breakpoint = Span;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Error {


### PR DESCRIPTION
Discussed breakpoint representation with Ryan today.

### Representing breakpoints

We decided to use `Span`s to represent these, since:
1. We can map each `Span` to a unique expression or decl in the program for which the stepper should pause execution.
2. We can map each line number to a `Span` that comes first, in terms of the order that the VM steps it.

Using fact 2, the UI can map a line number to a span, and feed this to the VM, which by virtue of 1, can accept fine-grained breakpoints that only exist within a line.

### Communicating and controlling breakpoints

After much thought today, the breakpoints appear to the VM as additional `Limits` information (adding field there for breakpoints).

Why put them here, and why a vector?

- As discussed with Ryan, it's abnormal to have more than one or two breakpoints, and certainly strange to have a large number of them.

- Further, I realized after our discussion today that the interaction with a breakpoint is multi-part, and we need to temporarily "clear" it to advance beyond it.  The UI thus needs to reset breakpoints for each step while they are active to get the following to work:

  a. set breakpoint X
  b. step until X, where the VM pauses.
  c. Then the UI removes X from breakpoints vector of the VM merely to step it, then re-add it immediately again to reflect the user's desire to break there.  All of this is "hidden" from the user, who just "steps into/over" the breakpoint.
  d. continue to step as needed
  
  Because step c involves some dance with the VM and UI to work, it'll be easier if the breakpoints are even more transitory, and not even stored in the VM for now.  This PR chooses that design by using `Limits` instead.