### PR TITLE
Update enum serialization for UI and formatter

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -29,6 +29,7 @@ impl<X> Node<X> {
 pub type Span = Range<usize>;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "source_type")]
 pub enum Source {
     Known { span: Span, line: usize, col: usize },
     Unknown,

--- a/src/lib/lexer_types.rs
+++ b/src/lib/lexer_types.rs
@@ -21,6 +21,7 @@ pub type Token_ = Loc<Token>;
 pub type Tokens = Vec<Token_>;
 
 #[derive(Logos, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "token_type", content = "data")]
 pub enum Token {
     // BlockComment(Data),
     #[regex(r"//[^\n]*", data)]
@@ -153,6 +154,7 @@ impl GroupType {
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "token_tree_type", content = "data")]
 pub enum TokenTree {
     Token(Token_),
     Group(Vec<TokenTree>, GroupType, Option<(Token_, Token_)>),


### PR DESCRIPTION
Updates the serialization format for `TokenTree`, `Token`, and `Source` for use in the VM user interface and Prettier plugin. 

[Deployed UI](https://mo-vm.netlify.app/) (includes a basic continuation source visualization)