### PR TITLE
VM: Tuple projection.

### DIFF
--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -186,6 +186,7 @@ fn exp_step(core: &mut Core, exp: Exp_, _limits: &Limits) -> Result<Step, Interr
             exp_conts(core, FrameCont::Annot(t), e)
         }
         Assign(e1, e2) => exp_conts(core, FrameCont::Assign1(e2), e1),
+        Proj(e1, i) => exp_conts(core, FrameCont::Proj(i), e1),
         _ => todo!(),
     }
 }
@@ -374,6 +375,18 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
                 core.cont = Cont::Value(v);
                 Ok(Step {})
             }
+            Proj(i) => match v {
+                Value::Tuple(vs) => {
+                    if i < vs.len() {
+                        let vi = vs.get(i).unwrap();
+                        core.cont = Cont::Value(vi.clone());
+                        Ok(Step {})
+                    } else {
+                        Err(Interruption::TypeMismatch)
+                    }
+                }
+                _ => Err(Interruption::TypeMismatch),
+            },
             _ => todo!(),
         }
     }

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -51,6 +51,7 @@ pub mod stack {
         Annot(Type_),
         Assign1(Exp_),
         Assign2(Pointer),
+        Proj(usize),
     }
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Frame {

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -55,3 +55,10 @@ fn vm_vars() {
     assert_("var x = 1; x := 2; x", "2");
     assert_x("1 := 1", &Interruption::TypeMismatch);
 }
+
+#[test]
+fn vm_tuple_proj() {
+    assert_("(1, 2).0", "1");
+    assert_("(1, 2).1", "2");
+    assert_x("(1, 2).2", &Interruption::TypeMismatch);
+}


### PR DESCRIPTION
Project from tuples.

It is a type error to project an index that is too large.

It is a type error to project a numerical field from a non-tuple.