### PR TITLE
VM: Records (objects without methods).

### DIFF
--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -15,7 +15,8 @@ pub type Text = Vector<String>;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FieldValue {
     pub mut_: Mut,
-    pub value: Value,
+    pub id: Id,
+    pub val: Value,
 }
 
 pub type Value_ = Box<Value>;

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -30,7 +30,8 @@ pub enum Cont {
 pub mod stack {
     use super::{Cont, Env, Vector};
     use crate::ast::{
-        BinOp, Cases, Dec_, Exp_, Id, Id_, Mut, Pat, PrimType, RelOp, Source, Type_, UnOp,
+        BinOp, Cases, Dec_, ExpField_, Exp_, Id, Id_, Mut, Pat, PrimType, RelOp, Source, Type_,
+        UnOp,
     };
     use crate::value::Value;
     use serde::{Deserialize, Serialize};
@@ -54,10 +55,12 @@ pub mod stack {
         Decs(Vector<Dec_>),
         Tuple(Vector<Value>, Vector<Exp_>),
         Array(Mut, Vector<Value>, Vector<Exp_>),
+        Object(Vector<FieldValue>, FieldContext, Vector<ExpField_>),
         Annot(Type_),
         Assign1(Exp_),
         Assign2(Value),
         Proj(usize),
+        Dot(Id_),
         If(Exp_, Option<Exp_>),
         RelOp1(RelOp, Exp_),
         RelOp2(Value, RelOp),
@@ -72,6 +75,19 @@ pub mod stack {
         pub source: Source,
     }
     pub type Frames = im_rc::Vector<Frame>;
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct FieldValue {
+        pub mut_: Mut,
+        pub id: Id_,
+        pub typ: Option<Type_>,
+        pub val: Value,
+    }
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct FieldContext {
+        pub mut_: Mut,
+        pub id: Id_,
+        pub typ: Option<Type_>,
+    }
 }
 
 pub type Stack = stack::Frames;

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -141,3 +141,28 @@ fn vm_array() {
         &Interruption::IndexOutOfBounds,
     );
 }
+
+#[test]
+fn vm_records() {
+    assert_("{ x = 3; y = 5; z = 8 }", "{ x = 3; y = 5; z = 8 }");
+    assert_("{ x = 3; y = 5; z = 8 }", "{ z = 8; y = 5; x = 3 }");
+
+    assert_("{ x = 3 }.x", "3");
+    assert_("let x = { x = 3 }; x.x", "3");
+
+    assert_("{ var x = 0 }.x := 1", "()");
+    assert_("let r = { var r = 0 }; r.r := 1; r.r", "1");
+
+    // to do -- need to traverse pointers for equality check to works
+    if false {
+        assert_("{ var z = 8; var y = 5 }", "{ var y = 5; var z = 8 }");
+    }
+
+    // to do -- equality that is quotiented by type annotations that narrow the type.
+    if false {
+        assert_(
+            "let r1 : { x : Nat } = { x = 3; y = 5}; r1 == { x = 3}",
+            "true",
+        );
+    }
+}


### PR DESCRIPTION
Leaving two issues unresolved for this PR, to be resolved in future ones.

- Dereference pointers when comparing records for equality -- https://github.com/dfinity/motoko.rs/issues/39
- Ignore "sealed" fields when comparing records for equality -- https://github.com/dfinity/motoko.rs/issues/40