### PR TITLE
VM: Logical, short-circuiting operations.

### DIFF
--- a/src/lib/parser.lalrpop
+++ b/src/lib/parser.lalrpop
@@ -350,6 +350,22 @@ ExpBin_<B>: Exp_ = Node<ExpBin<B>>;
 ExpBin<B>: Exp = {
     <e1:ExpBin_<B>> "==" <e2:ExpBin0_<B>> => Exp::Rel(e1, RelOp::Eq, e2),
     <e1:ExpBin_<B>> "!=" <e2:ExpBin0_<B>> => Exp::Rel(e1, RelOp::Neq, e2),
+    ExpBin000<B>,
+}
+
+#[inline]
+ExpBin000_<B>: Exp_ = Node<ExpBin000<B>>;
+
+ExpBin000<B>: Exp = {
+    <e1:ExpBin000_<B>> "or" <e2:ExpBin00_<B>> => Exp::Or(e1, e2),
+    ExpBin00<B>,
+}
+
+#[inline]
+ExpBin00_<B>: Exp_ = Node<ExpBin00<B>>;
+
+ExpBin00<B>: Exp = {
+    <e1:ExpBin00_<B>> "and" <e2:ExpBin0_<B>> => Exp::And(e1, e2),
     ExpBin0<B>,
 }
 

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -66,6 +66,11 @@ pub mod stack {
         RelOp2(Value, RelOp),
         While1(Exp_, Exp_),
         While2(Exp_, Exp_),
+        And1(Exp_),
+        And2,
+        Or1(Exp_),
+        Or2,
+        Not,
     }
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Frame {

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -166,3 +166,19 @@ fn vm_records() {
         );
     }
 }
+
+#[test]
+fn vm_boolean_ops() {
+    assert_("false or true", "true");
+    assert_("true or (do { while true { } ; false })", "true");
+    assert_x("false or 1", &Interruption::TypeMismatch);
+    assert_x("1 or true", &Interruption::TypeMismatch);
+
+    assert_("true and false", "false");
+    assert_("false and (do { while true { } ; false })", "false");
+    assert_x("true and 1", &Interruption::TypeMismatch);
+    assert_x("1 and true", &Interruption::TypeMismatch);
+
+    assert_("not false", "true");
+    assert_("not true", "false");
+}


### PR DESCRIPTION
Boolean operations:

- Short-circuiting `and` and `or`.

- Also `not`.

Note: Some tech debt is building up in the parser, but it's manageable.