### PR TITLE
VM: Debug blocks.

### DIFF
--- a/src/lib/parser.lalrpop
+++ b/src/lib/parser.lalrpop
@@ -346,6 +346,7 @@ ExpNonDec<B>: Exp = {
     "do" <e:Block_> => Exp::Do(e),
     "do" "?" <e:Block_> => Exp::DoOpt(e),
     "assert" <e:ExpNest_> => Exp::Assert(e),
+    "debug" <e:ExpNest_> => Exp::Debug(e),
 }
 
 #[inline]

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -282,6 +282,7 @@ fn exp_step(core: &mut Core, exp: Exp_, _limits: &Limits) -> Result<Step, Interr
         DoOpt(e) => exp_conts(core, FrameCont::DoOpt, e),
         Bang(e) => exp_conts(core, FrameCont::Bang, e),
         Ignore(e) => exp_conts(core, FrameCont::Ignore, e),
+        Debug(e) => exp_conts(core, FrameCont::Debug, e),
         _ => todo!(),
     }
 }
@@ -687,6 +688,13 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
                     } else {
                         Err(Interruption::TypeMismatch)
                     }
+                }
+                _ => Err(Interruption::TypeMismatch),
+            },
+            Debug => match v {
+                Value::Unit => {
+                    core.cont = Cont::Value(v);
+                    Ok(Step {})
                 }
                 _ => Err(Interruption::TypeMismatch),
             },

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -281,6 +281,7 @@ fn exp_step(core: &mut Core, exp: Exp_, _limits: &Limits) -> Result<Step, Interr
         Opt(e) => exp_conts(core, FrameCont::Opt, e),
         DoOpt(e) => exp_conts(core, FrameCont::DoOpt, e),
         Bang(e) => exp_conts(core, FrameCont::Bang, e),
+        Ignore(e) => exp_conts(core, FrameCont::Ignore, e),
         _ => todo!(),
     }
 }
@@ -588,6 +589,10 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
                 Value::Bool(false) => Err(Interruption::AssertionFailure),
                 _ => Err(Interruption::TypeMismatch),
             },
+            Ignore => {
+                core.cont = Cont::Value(Value::Unit);
+                Ok(Step {})
+            }
             Tuple(mut done, mut rest) => {
                 done.push_back(v);
                 match rest.pop_front() {

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -53,6 +53,7 @@ pub mod stack {
         Do,
         Assert,
         Ignore,
+        Debug,
         Block,
         Decs(Vector<Dec_>),
         Tuple(Vector<Value>, Vector<Exp_>),

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -52,6 +52,7 @@ pub mod stack {
         Switch(Cases),
         Do,
         Assert,
+        Ignore,
         Block,
         Decs(Vector<Dec_>),
         Tuple(Vector<Value>, Vector<Exp_>),

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -208,3 +208,9 @@ fn return_() {
     assert_("func f ( x ) { return x; while true { } }; f 3", "3");
     assert_("let y = 3; func f ( x ) { return y }; f 4", "3");
 }
+
+#[test]
+fn ignore() {
+    assert_("ignore 3", "()");
+    assert_("ignore 1 + 1", "()");
+}

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -214,3 +214,9 @@ fn ignore() {
     assert_("ignore 3", "()");
     assert_("ignore 1 + 1", "()");
 }
+
+#[test]
+fn debug() {
+    assert_("debug { () }", "()");
+    assert_x("debug { 3 }", &Interruption::TypeMismatch);
+}


### PR DESCRIPTION
- `debug { ... }` blocks.
- to do: CLI and flags for controlling them.  For now, always on (default of `moc`).