### PR TITLE
VM: Recursive functions. Logging output in tests.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ logos = "0.12.1"
 line-col = "0.2.1"
 im-rc = { version = "15.1.0", features = ["serde"] }
 serde = { version = "1.0.143", features = ["derive"] }
+test-log = "0.2.11"
 
 [lib]
 name = "motoko"

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -281,6 +281,7 @@ fn exp_step(core: &mut Core, exp: Exp_, _limits: &Limits) -> Result<Step, Interr
         Opt(e) => exp_conts(core, FrameCont::Opt, e),
         DoOpt(e) => exp_conts(core, FrameCont::DoOpt, e),
         Bang(e) => exp_conts(core, FrameCont::Bang, e),
+        Ignore(e) => exp_conts(core, FrameCont::Ignore, e),
         _ => todo!(),
     }
 }
@@ -588,6 +589,10 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
                 Value::Bool(false) => Err(Interruption::AssertionFailure),
                 _ => Err(Interruption::TypeMismatch),
             },
+            Ignore => {
+                core.cont = Cont::Value(Value::Unit);
+                Ok(Step {})
+            }
             Tuple(mut done, mut rest) => {
                 done.push_back(v);
                 match rest.pop_front() {

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -167,6 +167,10 @@ fn call_function(
     if let Some(env_) = pattern_matches(&cf.0.env, &cf.0.content.3 .0, &args) {
         let source = core.cont_source.clone();
         core.env = env_;
+        cf.0.content
+            .0
+            .clone()
+            .map(|f| core.env.insert(*f.0, Value::Function(cf.clone())));
         core.cont = Cont::Exp_(cf.0.content.6.clone(), Vector::new());
         core.stack.push_front(Frame {
             source,

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -52,6 +52,7 @@ pub mod stack {
         Switch(Cases),
         Do,
         Assert,
+        Ignore,
         Block,
         Decs(Vector<Dec_>),
         Tuple(Vector<Value>, Vector<Exp_>),

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,22 @@
+### Viewing `env_logger` output in failing tests.
+
+Because logs go to standard error, not standard output, that behavior
+is misaligned with the setup of `cargo test -- --nocapture`, which
+only looks at `stdout`, and ignores `stderr`.
+
+To fix this undesirable default, we use this package:
+
+https://github.com/d-e-s-o/test-log
+
+It redirects logging to `stdout`, which is what we want for tests run with `cargo test`.
+
+And this `use test_log::test;` appears in the tests that use it.
+
+To see the full output of logging, invoke `cargo test` this way:
+
+`RUST_LOG=trace cargo test -- --nocapture`
+
+Note two important feature of this CLI invocation:
+
+ - Using `RUST_LOG=trace` to set the log level to `trace`, giving maximal output for failing tests.
+ - Using `-- --nocapture` to suppress the default test behavior of capturing and omitting `stdout`

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -208,3 +208,9 @@ fn return_() {
     assert_("func f ( x ) { return x; while true { } }; f 3", "3");
     assert_("let y = 3; func f ( x ) { return y }; f 4", "3");
 }
+
+#[test]
+fn ignore() {
+    assert_("ignore 3", "()");
+    assert_("ignore 1 + 1", "()");
+}

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -2,6 +2,8 @@ use motoko::check::assert_vm_eval as assert_;
 use motoko::check::assert_vm_interruption as assert_x;
 use motoko::vm_types::Interruption;
 
+use test_log::test; // enable logging output for tests by default.
+
 fn assert_is_value(v: &str) {
     assert_(v, v)
 }
@@ -199,6 +201,14 @@ fn function_call() {
     assert_("func f (x: Nat) : Nat { x }; f 3", "3");
     assert_("func f ( x ) { x }; f 3", "3");
     assert_("let y = 3; func f ( x ) { y }; f 4", "3");
+}
+
+#[test]
+fn function_rec_call() {
+    assert_(
+        "(func f (x) { if (x == 0) { 123 } else { f (x - 1) } }) 1",
+        "123",
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Fixes #45 to permit recursive functions.
- Adds a crate to help get logs out of VM tests.
- Adds docs for using this `test-log` crate in general.