### PR TITLE
VM: Modules.

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -160,6 +160,7 @@ pub type Dec_ = Node<Dec>;
 pub enum Dec {
     Exp(Exp),
     Let(Pat_, Exp_),
+    LetModule(Option<Id_>, Sugar, DecFields),
     Func(Function),
     Var(Pat_, Exp_),
     Type(TypId_, TypeBinds, Type_),
@@ -240,8 +241,8 @@ pub type DecField_ = Node<DecField>;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DecField {
     pub dec: Dec_,
-    pub vis: Option<Vis>,
-    pub stab: Option<Stab>,
+    pub vis: Option<Vis_>,
+    pub stab: Option<Stab_>,
 }
 
 pub type PatField_ = Node<PatField>;
@@ -261,12 +262,16 @@ pub struct TypeField {
     pub typ: Type_,
 }
 
+pub type Vis_ = Node<Vis>;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Vis {
     Public(Option<Id_>),
     Private,
     System,
 }
+
+pub type Stab_ = Node<Stab>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Stab {

--- a/src/lib/ast_traversal.rs
+++ b/src/lib/ast_traversal.rs
@@ -307,6 +307,7 @@ impl<'a> Traverse for Loc<&'a Dec> {
                 f(&p.tree());
                 f(&e.tree());
             }
+            Dec::LetModule(_, _, _) => todo!(),
             Dec::Func(_) => todo!(),
             Dec::Var(p, e) => {
                 f(&p.tree());

--- a/src/lib/format.rs
+++ b/src/lib/format.rs
@@ -312,6 +312,7 @@ impl ToDoc for Dec {
                 .append(p.doc())
                 .append(str(" = "))
                 .append(e.doc()),
+            LetModule(_, _, _) => todo!(),
             Func(_) => todo!(),
             Var(p, e) => kwd("var")
                 .append(p.doc())

--- a/src/lib/parser.lalrpop
+++ b/src/lib/parser.lalrpop
@@ -2,7 +2,7 @@
 //use std::collections::HashMap;
 // use crate::ast_utils::Syntax;
 use crate::parser_utils::{dec_node_into_exp, get_one, node};
-use crate::ast::{Node, Source, Id, Id_, Pat, Pat_, Exp, Exp_, ExpField, Type, Type_, PrimType, Literal, Case, Cases, Decs, Dec, Dec_, UnOp, BinOp, RelOp, Delim, Mut, SortPat, SortPat_, Sugar};
+use crate::ast::{Node, Source, Id, Id_, Pat, Pat_, Exp, Exp_, ExpField, Type, Type_, PrimType, Literal, Case, Cases, Decs, Dec, Dec_, UnOp, BinOp, RelOp, Delim, Mut, SortPat, SortPat_, Sugar, Vis, Vis_, Stab, Stab_, DecField, DecField_, DecFields};
 // use crate::lexer_types::Token;
 use line_col::LineColLookup;
 
@@ -448,6 +448,7 @@ DecNonVar_: Dec_ = Node<DecNonVar>;
 
 DecNonVar: Dec = {
     "let" <p:Pat_> "=" <e:Exp_<Ob>> => Dec::Let(p, e),
+    "module" <i:(Id_)?> <s:"="?> <ob:ObjBody> => Dec::LetModule(i, Sugar(s.is_some()), ob),
     <sp:SortPat_> "func" <i:(Id_)?> <p:PatPlain_> <t:(":" Type_)?> <b:Block_> => Dec::Func((i, sp, Delim::new(), p, t.map(|t|{t.1}), Sugar(false), b)),
     <sp:SortPat_> "func" <i:(Id_?)> <p:PatPlain_> <t:(":" Type_)?> "=" <e:Exp_<Ob>> => Dec::Func((i, sp, Delim::new(), p, t.map(|t|{t.1}), Sugar(true), e)),
     // type
@@ -494,6 +495,33 @@ BinOp: BinOp = {
     "<<>" => BinOp::RotL,
     "<>>" => BinOp::RotR,
     "#" => BinOp::Cat,
+}
+
+ObjBody: DecFields = {
+    "{" <dfs:Delim0<DecField_, ";">> "}" => dfs
+}
+
+#[inline]
+Vis_: Vis_ = Node<Vis>;
+
+Vis: Vis = {
+  "public" => Vis::Private,
+  "private" => Vis::Private,
+}
+
+#[inline]
+Stab_: Stab_ = Node<Stab>;
+
+Stab: Stab = {
+  "stable" => Stab::Stable,
+  "flexible" => Stab::Flexible,
+}
+
+#[inline]
+DecField_: DecField_ = Node<DecField>;
+
+DecField: DecField = {
+    <vis:(Vis_)?> <stab:(Stab_)?> <dec:Dec_> => DecField{ vis, stab, dec }
 }
 
 // Precedence

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -953,6 +953,9 @@ fn core_step(core: &mut Core, limits: &Limits) -> Result<Step, Interruption> {
                             exp_conts(core, FrameCont::Let(*p.0, Cont::Decs(decs)), e)
                         }
                     }
+                    Dec::LetModule(i, _, dfs) => {
+                        todo!("modules")
+                    }
                     Dec::Var(p, e) => match *p.0 {
                         Pat::Var(x) => exp_conts(core, FrameCont::Var(*x.0, Cont::Decs(decs)), e),
                         _ => todo!(),

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -244,6 +244,8 @@ fn for_() {
 
 #[test]
 fn module() {
-    assert_("module X { public let x = 5; let y = (1, 2); func f () { } }",
-            "module X { public let x = 5; let y = (1, 2); func f () { } }");
+    assert_(
+        "module X { public let x = 5; let y = (1, 2); func f () { } }",
+        "module X { public let x = 5; let y = (1, 2); func f () { } }",
+    );
 }

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -241,3 +241,9 @@ fn for_() {
     assert_(
         "var x = 13; var c = 0; let i = { next = func () { if (x == 0) { null } else { x := x - 1; c := c + 1; ?x } } }; for (j in i) { let _ = j; }; c", "13");
 }
+
+#[test]
+fn module() {
+    assert_("module X { public let x = 5; let y = (1, 2); func f () { } }",
+            "module X { public let x = 5; let y = (1, 2); func f () { } }");
+}


### PR DESCRIPTION
This PR implements modules for the VM.  (WIP)

1. For each module, combine names defined in the module to create a valid environment.  Reusing the same name is an `Interruption`
2. combine names in nested modules, and also permit outer names to flow into these internal modules.  Unlike in`Rust`, in Motoko, all names in super scopes flow into subscopes.

Unlike other constructs, modules require doing a lot of steps that do not correspond to ordinary execution, but rather, correspond to phases just before or during type checking.

These steps are necessary to resolve identifiers and module projections in real Motoko programs, and involve resolving nested recursive definitions.

Each named module definition introduces a recursive scope that we construct incrementally, in a step-wise manner.  When they nest, additional steps propagate the recursion between the nested levels.

##### Why?

We could eschew a step-based approach, and do the module-level resolution of paths in a batch style, with batch-style errors each time an identifier is used twice.  However, that has two drawbacks:

1. Goes against the rest of the project, where we show internal progress at every possible step and interrupt it immediately when there is an issue.  A batch algorithm is not like this, and would introduce another "mode" of interacting with programs that happens before they "run step by step".  That would complicate things, including the UX design, potentially.
3. If we ever want to improvise with other pre-execution steps, this would introduce a place to do them.  Such steps may include experimental intensional features, like `let box`; as with modules, they would step before the program evaluates. 

#### Scoping using nested `module`s

Consider [this nested `module` declaration](https://embed.smartcontracts.org/motoko/g/2wC8uxVtJsd5waSKvXLNGGoTiEdfykMhx3GkZoScfGStxowJixiaRkwiXDro52r2mYi8Ken2KwcXgcFhEouJY3M6weE73jtJVdJ3MH3cWsbiS7gGj5LUEZ7RR6v1Mc52ZbouDYVncRpjrEpaXuiTh9J2fxwSbvqRhH3YyW7nQcyoHVwXK5kDVCJeEr85AwmCCP6pgK73Z7Jgz4BzoAdcvFhMKtLtGwYKkTow18bWFL6ubbKaojKm5JCcMwiA226NQjt111Ue8Tx8yrAd2UzMwMgYTEKKbDFaKkMS9APBH):

```
module {
  module X {
    /* module Y { }; */ // will shadow Y sibling of X
    public module M {
      func f () : Nat { 
           g();h
           N.g();
           M.g();
           /* X.N.g() */
           x
      };
      public func g () { Y.y(); Y.Z.z() };
    };
    module N {
      public func g () { Y.y(); /* Z.z() /* error. */ */ };
    };  
    public let x = 5;
  };

  module Y {
    public module Z { public func z() { Y.y(); y() } };
    public func y() { X.M.g() };
  };
}
```

Notice:
- function `X.M.g` can "see" `Y.y` and `Y.Z.z`.
- function `Y.Z.z` can "see" function "y" and also see the same function as `Y.y`.
- function `X.N.g` can "see" `Y.y` but not `Z.z` (`Y.Z.z()` works though)

This example could be smaller and simpler.  It's something I have been using as I poke at the compiler to test my understanding of the language, and having it be about this large as been helpful.