### PR TITLE
VM: Debug.print

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -5,10 +5,10 @@ pub mod format;
 mod format_utils;
 pub mod lexer;
 pub mod lexer_types;
+pub mod package;
 #[allow(clippy::all)]
 pub mod parser;
 mod parser_utils;
 pub mod value;
-pub mod package;
 pub mod vm;
 pub mod vm_types;

--- a/src/lib/parser.lalrpop
+++ b/src/lib/parser.lalrpop
@@ -163,7 +163,11 @@ pub Literal: Literal = {
     r"0x[0-9a-fA-F]+" => Literal::Nat(<>.to_string()), // hexadecimal
     r"[0-9]([0-9_]*[0-9])?" => Literal::Nat(<>.to_string()),
     r"'(?:[^\\']|\\.)*'" => Literal::Char(<>.to_string()), // TODO: more test cases
-    r#""(?:[^\\"]|\\.)*""# => Literal::Text(<>.to_string()), // TODO more test cases
+    <s:StringLiteral> => Literal::Text(s),
+}
+
+StringLiteral: String = {
+    r#""(?:[^\\"]|\\.)*""# => <>.to_string(), // TODO more test cases
 }
 
 // --- Patterns --- //
@@ -263,7 +267,7 @@ ExpNullary<B>: Exp = {
     B,
     ExpPlain,
     Id => Exp::Var(<>),
-    // Prim
+    "prim" <sl:StringLiteral> => Exp::Prim(sl), // to do -- trim '"' '"'
 }
 
 #[inline]

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 // use float_cmp::ApproxEq; // in case we want to implement the `Eq` trait for `Value`
 
 /// Permit sharing, and fast concats.
-pub type Text = Vector<String>;
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Text(pub Vector<String>);
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FieldValue {
@@ -47,6 +48,12 @@ pub enum Value {
     Pointer(Pointer),
     ArrayOffset(Pointer, usize),
     Function(ClosedFunction),
+    PrimFunction(PrimFunction),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrimFunction {
+    DebugPrint,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -116,7 +123,7 @@ impl Value {
                     .parse()
                     .map_err(ValueError::ParseCharError)?,
             ),
-            Literal::Text(s) => Text(vector![s[1..s.len() - 1].to_string()]),
+            Literal::Text(s) => Text(crate::value::Text(vector![s[1..s.len() - 1].to_string()])),
             Literal::Blob(v) => Blob(v),
         })
     }

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -2,7 +2,7 @@ use crate::ast::{
     BinOp, Cases, Dec, Dec_, Exp, Exp_, Inst, Mut, Pat, PrimType, Prog, RelOp, Source, Type, UnOp,
 };
 use crate::ast_traversal::ToNode;
-use crate::value::{Closed, ClosedFunction, Value};
+use crate::value::{Closed, ClosedFunction, PrimFunction, Value};
 use crate::vm_types::{
     stack::{FieldContext, FieldValue, Frame, FrameCont},
     Breakpoint, Cont, Core, Counts, Env, Error, Interruption, Limit, Limits, Local, Pointer,
@@ -41,6 +41,7 @@ fn core_init(prog: Prog) -> Core {
         cont: Cont::Decs(prog.vec.into()),
         cont_source: Source::CoreInit, // special source -- or get the "full span" (but then what line or column number would be helpful here?  line 1 column 0?)
         cont_prim_type,
+        debug_print_out: Vector::new(),
         counts: Counts {
             step: 0,
             /*
@@ -156,6 +157,26 @@ fn exp_conts(core: &mut Core, frame_cont: FrameCont, cont: Exp_) -> Result<Step,
         Cont::Exp_(cont, Vector::new()),
         cont_source,
     )
+}
+
+fn call_prim_function(
+    core: &mut Core,
+    pf: PrimFunction,
+    _targs: Option<Inst>,
+    args: Value,
+) -> Result<Step, Interruption> {
+    use PrimFunction::*;
+    match pf {
+        DebugPrint => match args {
+            Value::Text(s) => {
+                log::info!("DebugPrint: {}: {:?}", core.cont_source, s);
+                core.debug_print_out.push_back(s);
+                core.cont = Cont::Value(Value::Unit);
+                Ok(Step {})
+            }
+            _ => Err(Interruption::TypeMismatch),
+        },
+    }
 }
 
 fn call_function(
@@ -312,6 +333,13 @@ fn exp_step(core: &mut Core, exp: Exp_, _limits: &Limits) -> Result<Step, Interr
         Bang(e) => exp_conts(core, FrameCont::Bang, e),
         Ignore(e) => exp_conts(core, FrameCont::Ignore, e),
         Debug(e) => exp_conts(core, FrameCont::Debug, e),
+        Prim(s) => match &s.as_str() {
+            &"\"debugPrint\"" => {
+                core.cont = Cont::Value(Value::PrimFunction(PrimFunction::DebugPrint));
+                Ok(Step {})
+            }
+            s => todo!("Prim({})", s),
+        },
         _ => todo!(),
     }
 }
@@ -843,9 +871,11 @@ fn stack_cont(core: &mut Core, limits: &Limits, v: Value) -> Result<Step, Interr
             },
             Call1(inst, e2) => match v {
                 Value::Function(cf) => exp_conts(core, FrameCont::Call2(cf, inst), e2),
+                Value::PrimFunction(pf) => exp_conts(core, FrameCont::Call2Prim(pf, inst), e2),
                 _ => Err(Interruption::TypeMismatch),
             },
             Call2(cf, inst) => call_function(core, cf, inst, v),
+            Call2Prim(pf, inst) => call_prim_function(core, pf, inst, v),
             Call3 => {
                 core.cont = Cont::Value(v);
                 Ok(Step {})

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -35,7 +35,7 @@ pub mod stack {
         BinOp, Cases, Dec_, ExpField_, Exp_, Id, Id_, Inst, Mut, Pat, Pat_, PrimType, RelOp,
         Source, Type_, UnOp,
     };
-    use crate::value::{ClosedFunction, Value};
+    use crate::value::{ClosedFunction, PrimFunction, Value};
     use serde::{Deserialize, Serialize};
 
     /// Local continuation, stored in a stack frame.
@@ -83,6 +83,7 @@ pub mod stack {
         Bang,
         Call1(Option<Inst>, Exp_),
         Call2(ClosedFunction, Option<Inst>),
+        Call2Prim(PrimFunction, Option<Inst>),
         Call3,
         Return,
     }
@@ -147,6 +148,7 @@ pub struct Core {
     /// (`e : Nat8`  makes `Nat8` the `cont_prim_type` for `e`)
     pub cont_prim_type: Option<PrimType>,
     pub counts: Counts,
+    pub debug_print_out: Vector<crate::value::Text>,
 }
 
 /// Encapsulates the VM state running Motoko code locally,

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -241,3 +241,12 @@ fn for_() {
     assert_(
         "var x = 13; var c = 0; let i = { next = func () { if (x == 0) { null } else { x := x - 1; c := c + 1; ?x } } }; for (j in i) { let _ = j; }; c", "13");
 }
+
+#[test]
+fn prim_debug_print() {
+    assert_("prim \"debugPrint\" \"hello, world\"", "()");
+    assert_(
+        "let Debug = { print = prim \"debugPrint\" }; Debug.print \"hello, world\"",
+        "()",
+    );
+}


### PR DESCRIPTION
- recognize `prim "debugPrint"` and do two effects:
   - print the argument (a `Text` value) to the VM's Rust-level log
   - add the argument to the `Core`'s new field, `debug_print_out`, a `Vector` of `Text` values that have been printed.
   
   
- future work: recognize `Debug.print` without pre-loading the `Core` with any special preamble code, like this:
   ```
   let Debug = { print = prim \"debugPrint\" }; Debug.print \"hello, world\"
   ```
    but without having to define `Debug`.