### PR TITLE
VM: Fix: function call return restores old environment.

### DIFF
--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -408,6 +408,7 @@ fn return_(core: &mut Core, v: Value) -> Result<Step, Interruption> {
         if let Some(fr) = stack.pop_front() {
             match fr.cont {
                 FrameCont::Call3 => {
+                    core.env = fr.env;
                     core.stack = stack;
                     core.cont = Cont::Value(v);
                     return Ok(Step {});

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -187,6 +187,7 @@ fn call_function(
 ) -> Result<Step, Interruption> {
     if let Some(env_) = pattern_matches(&cf.0.env, &cf.0.content.3 .0, &args) {
         let source = core.cont_source.clone();
+        let env_saved = core.env.clone();
         core.env = env_;
         cf.0.content
             .0
@@ -195,7 +196,7 @@ fn call_function(
         core.cont = Cont::Exp_(cf.0.content.6.clone(), Vector::new());
         core.stack.push_front(Frame {
             source,
-            env: HashMap::new(),
+            env: env_saved,
             cont: FrameCont::Call3,
             cont_prim_type: None, /* to do */
         }); // to match with Return, if any.
@@ -408,8 +409,8 @@ fn return_(core: &mut Core, v: Value) -> Result<Step, Interruption> {
         if let Some(fr) = stack.pop_front() {
             match fr.cont {
                 FrameCont::Call3 => {
-                    core.env = fr.env;
                     core.stack = stack;
+                    core.env = fr.env;
                     core.cont = Cont::Value(v);
                     return Ok(Step {});
                 }

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -250,3 +250,9 @@ fn prim_debug_print() {
         "()",
     );
 }
+
+#[test]
+fn function_call_return_restores_env() {
+    assert_("func f() { }; let x = 0; x", "0");
+    assert_("func f() { }; let x = 0; f(); x", "0");
+}


### PR DESCRIPTION
Consider this program:

```
func f() { };
let x = 0;
f(); 
x
```

Defining `x` expands the environment.  Calling `f` clears the environment, and returning should restore it to contain `x`.

This PR fixes the VM so that the environment before the call is saved and restored correctly.


###### Notes

Was playing with mo-vm and noticed a bug when this program failed.  This PR fixes the VM so it works.

```
var x = 6;
let Debug = {
  print = func (x) { prim "debugPrint" x }
};
let i = {
  next = func () { 
    if (x == 0) { null } else {
      x := x - 1; ?x
    }
  }
};
for (y in i) {
  if (y == 3) { Debug.print "goob" } else { };
  Debug.print "hello" 
}
```

