### PR TITLE
Implement syntax error propagation

### DIFF
--- a/src/bin/mo.rs
+++ b/src/bin/mo.rs
@@ -10,22 +10,29 @@ use motoko::vm_types::Limits;
 pub type OurResult<X> = Result<X, OurError>;
 
 impl From<()> for OurError {
-    fn from(_unit: ()) -> Self {
-        OurError::Unit
+    fn from(_: ()) -> Self {
+        OurError::Unknown
     }
 }
 
 impl From<motoko::vm_types::Error> for OurError {
-    fn from(vm: motoko::vm_types::Error) -> Self {
-        OurError::VM(vm)
+    fn from(err: motoko::vm_types::Error) -> Self {
+        OurError::VM(err)
+    }
+}
+
+impl From<motoko::parser_types::SyntaxError> for OurError {
+    fn from(err: motoko::parser_types::SyntaxError) -> Self {
+        OurError::Syntax(err)
     }
 }
 
 #[derive(Debug, Clone)]
 pub enum OurError {
-    Unit,
+    Unknown,
     String(String),
     VM(motoko::vm_types::Error),
+    Syntax(motoko::parser_types::SyntaxError),
 }
 
 /// Motoko tools in Rust.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -8,6 +8,7 @@ pub mod lexer_types;
 pub mod package;
 #[allow(clippy::all)]
 pub mod parser;
+pub mod parser_types;
 mod parser_utils;
 pub mod value;
 pub mod vm;

--- a/src/lib/parser_types.rs
+++ b/src/lib/parser_types.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+// TODO: move?
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SyntaxError {
+    InvalidToken {
+        location: usize,
+    },
+    UnrecognizedEOF {
+        location: usize,
+        expected: Vec<String>,
+    },
+    UnrecognizedToken {
+        token: String,
+        start: usize,
+        end: usize,
+        expected: Vec<String>,
+    },
+    ExtraToken {
+        token: String,
+        start: usize,
+        end: usize,
+    },
+    Custom(String),
+}
+
+impl SyntaxError {
+    pub fn from_parse_error<'input>(
+        err: lalrpop_util::ParseError<usize, lalrpop_util::lexer::Token<'input>, &'static str>,
+    ) -> SyntaxError {
+        use lalrpop_util::ParseError::*;
+        match err {
+            InvalidToken { location } => Self::InvalidToken { location },
+            UnrecognizedEOF { location, expected } => Self::UnrecognizedEOF { location, expected },
+            UnrecognizedToken { token, expected } => Self::UnrecognizedToken {
+                token: token.1.to_string(),
+                start: token.0,
+                end: token.2,
+                expected,
+            },
+            ExtraToken { token } => Self::ExtraToken {
+                token: token.1.to_string(),
+                start: token.0,
+                end: token.2,
+            },
+            User { error } => Self::Custom(error.to_owned()),
+        }
+    }
+}

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -232,7 +232,7 @@ fn exp_step(core: &mut Core, exp: Exp_, _limits: &Limits) -> Result<Step, Interr
     let source = exp.1.clone();
     match *exp.0 {
         Literal(l) => {
-            core.cont = Cont::Value(Value::from_literal(l).map_err(|_| Interruption::ParseError)?);
+            core.cont = Cont::Value(Value::from_literal(l).map_err(Interruption::ValueError)?);
             Ok(Step {})
         }
         Function(f) => {
@@ -1076,7 +1076,8 @@ pub fn eval_limit(prog: &str, limits: &Limits) -> Result<Value, Interruption> {
     info!("eval_limit:");
     info!("  - prog = {}", prog);
     info!("  - limits = {:#?}", limits);
-    let p = crate::check::parse(&prog)?;
+    use crate::vm_types::Interruption::SyntaxError;
+    let p = crate::check::parse(&prog).map_err(SyntaxError)?;
     info!("eval_limit: parsed.");
     let mut l = Local::new(Core::new(p));
     let s = l.run(limits).map_err(|_| ())?;

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -2,7 +2,8 @@ use im_rc::{HashMap, Vector};
 use serde::{Deserialize, Serialize};
 
 use crate::ast::{Dec_, Exp_, Id as Identifier, Id_, PrimType, Source, Span};
-use crate::value::Value;
+use crate::parser_types::SyntaxError;
+use crate::value::{Value, ValueError};
 
 /// Or maybe a string?
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -215,7 +216,8 @@ pub enum Interruption {
     Dangling(Pointer),
     TypeMismatch,
     NoMatchingCase,
-    ParseError,
+    SyntaxError(SyntaxError),
+    ValueError(ValueError),
     UnboundIdentifer(Identifier),
     BlockedAwaiting,
     Limit(Limit),


### PR DESCRIPTION
Makes it possible to determine line/column information for syntax errors, along with some general error refactoring.