### PR TITLE
Fix: redex-based limit fix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
Interrupt with limit check only after finishing all semantics for each case, just before returning `Ok`.

to do in future: merge this line that does `mark_redex` with the following line that returns `Ok(Step {})` in each case.