### PR TITLE
Fix redex limit (another try).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -213,6 +213,7 @@ pub struct Step {
 #[serde(tag = "interruption_type", content = "value")]
 pub enum Interruption {
     Done(Value),
+    Breakpoint(Breakpoint),
     Dangling(Pointer),
     TypeMismatch,
     NoMatchingCase,
@@ -241,7 +242,6 @@ pub struct NYI {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Signal {
     Done(Value),
-    Breakpoint(Breakpoint),
     Interruption(Interruption),
 }
 


### PR DESCRIPTION
Big clean up.

- re-organize all limit checks into one place, `core_step`.
- all limit checks happen before any mutation to `Core`, before calling `core_step_` or any of its helpers.
- internal mutations isolated to `core_step_`, and no limits are available to check anymore (too late!)
