### PR TITLE
Special `HashMap` primitives.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use serde::{Deserialize, Serialize};
 
 /// A "located `X`" has a source location of type `Source`.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Loc<X>(pub X, pub Source);
 
 impl<X: std::fmt::Debug> std::fmt::Debug for Loc<X> {
@@ -28,7 +28,7 @@ impl<X> Node<X> {
 
 pub type Span = Range<usize>;
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(tag = "source_type")]
 pub enum Source {
     Known { span: Span, line: usize, col: usize },
@@ -101,7 +101,7 @@ impl std::default::Default for Source {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Delim<X> {
     pub vec: Vec<X>,
     pub has_trailing: bool,
@@ -114,11 +114,17 @@ impl<X> Delim<X> {
             has_trailing: false,
         }
     }
+    pub fn from(vec: Vec<X>) -> Self {
+        Delim {
+            vec,
+            has_trailing: false,
+        }
+    }
 }
 
 pub type Literal_ = Node<Literal>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Literal {
     Null,
     Bool(bool),
@@ -131,14 +137,14 @@ pub enum Literal {
     Blob(Vec<u8>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum ObjSort {
     Object,
     Actor,
     Module,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Shared<T /*: std::fmt::Debug + Clone + PartialEq + Eq*/> {
     Local,
     Shared(T),
@@ -156,7 +162,7 @@ pub type Prog = Decs;
 
 pub type Dec_ = Node<Dec>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Dec {
     Exp(Exp),
     Let(Pat_, Exp_),
@@ -178,19 +184,19 @@ pub enum Dec {
 
 pub type SortPat_ = Node<SortPat>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum SortPat {
     Local,
     Shared(SharedSort, Pat_),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum SharedSort {
     Query,
     Update,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BindSort {
     Scope,
     Type,
@@ -198,7 +204,7 @@ pub enum BindSort {
 
 pub type TypeBind_ = Node<TypeBind>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct TypeBind {
     pub var: Id_,
     pub sort: BindSort,
@@ -206,7 +212,7 @@ pub struct TypeBind {
 }
 
 /// Mutability setting, for arrays, record fields and lexically-scoped bindings.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Mut {
     Const,
     Var,
@@ -220,7 +226,7 @@ pub type TypeFields = Delim<TypeField_>;
 
 pub type Case_ = Node<Case>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Case {
     pub pat: Pat_,
     pub exp: Exp_,
@@ -228,7 +234,7 @@ pub struct Case {
 
 pub type ExpField_ = Node<ExpField>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct ExpField {
     pub mut_: Mut,
     pub id: Id_,
@@ -238,7 +244,7 @@ pub struct ExpField {
 
 pub type DecField_ = Node<DecField>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct DecField {
     pub dec: Dec_,
     pub vis: Option<Vis_>,
@@ -247,7 +253,7 @@ pub struct DecField {
 
 pub type PatField_ = Node<PatField>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct PatField {
     pub id: Id_,
     pub pat: Pat_,
@@ -255,7 +261,7 @@ pub struct PatField {
 
 pub type TypeField_ = Node<TypeField>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct TypeField {
     pub mut_: Mut,
     pub id: Id_,
@@ -264,7 +270,7 @@ pub struct TypeField {
 
 pub type Vis_ = Node<Vis>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Vis {
     Public(Option<Id_>),
     Private,
@@ -273,13 +279,13 @@ pub enum Vis {
 
 pub type Stab_ = Node<Stab>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Stab {
     Stable,
     Flexible,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum ResolvedImport {
     Unresolved,
     Lib(String),
@@ -287,10 +293,10 @@ pub enum ResolvedImport {
     Prim,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Sugar(pub bool);
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum PrimType {
     Null,
     Unit,
@@ -313,7 +319,7 @@ pub enum PrimType {
 
 pub type Type_ = Node<Type>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Type {
     // Path (type path)?
     Prim(PrimType),
@@ -347,7 +353,7 @@ pub type Function = (
     Exp_,
 );
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Exp {
     Hole,
     Prim(Id),
@@ -401,7 +407,7 @@ pub enum Exp {
 
 pub type Pat_ = Node<Pat>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Pat {
     Wild,
     Var(Id_),
@@ -416,14 +422,14 @@ pub enum Pat {
     Paren(Pat_),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum UnOp {
     Pos,
     Neg,
     Not,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum BinOp {
     Add,
     Sub,
@@ -447,7 +453,7 @@ pub enum BinOp {
     BitAnd,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum RelOp {
     Eq,
     Neq,

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -9,10 +9,10 @@ use serde::{Deserialize, Serialize};
 // use float_cmp::ApproxEq; // in case we want to implement the `Eq` trait for `Value`
 
 /// Permit sharing, and fast concats.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Text(pub Vector<String>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct FieldValue {
     pub mut_: Mut,
     pub id: Id,
@@ -23,17 +23,17 @@ pub type Value_ = Box<Value>;
 
 pub type Pointer = crate::vm_types::Pointer;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct ClosedFunction(pub Closed<Function>);
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 pub enum Value {
     Null,
     Bool(bool),
     Unit,
     Nat(BigUint),
     Int(BigInt),
-    Float(f64),
+    //Float(f64),
     Char(char),
     Text(Text),
     Blob(Vec<u8>),
@@ -46,14 +46,33 @@ pub enum Value {
     ArrayOffset(Pointer, usize),
     Function(ClosedFunction),
     PrimFunction(PrimFunction),
+    Collection(Collection),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+pub enum Collection {
+    HashMap(HashMap<Value, Value>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum PrimFunction {
     DebugPrint,
+    Collection(CollectionFunction),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum CollectionFunction {
+    HashMap(HashMapFunction),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub enum HashMapFunction {
+    New,
+    Put,
+    Get,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Closed<X> {
     pub env: Env,
     pub content: X,
@@ -110,7 +129,7 @@ impl Value {
                 }
             }),
             // Literal::Int(i) => Int(i.parse()?),
-            Literal::Float(n) => Float(n.replace('_', "").parse().map_err(|_| ValueError::Float)?),
+            Literal::Float(_n) => todo!(), /* Float(n.replace('_', "").parse().map_err(|_| ValueError::Float)?), */
             Literal::Char(s) => Char(s[1..s.len() - 1].parse().map_err(|_| ValueError::Char)?),
             Literal::Text(s) => Text(crate::value::Text(vector![s[1..s.len() - 1].to_string()])),
             Literal::Blob(v) => Blob(v),

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -340,17 +340,18 @@ mod collection {
                 let hm = env.get("hm").unwrap();
                 let k = env.get("k").unwrap();
                 let v = env.get("v").unwrap();
-                let old = {
+                let (hm, old) = {
                     if let Value::Collection(Collection::HashMap(mut hm)) = hm.clone() {
                         match hm.insert(k.clone(), v.clone()) {
-                            None => Value::Null,
-                            Some(old) => Value::Option(Box::new(old)),
+                            None => (hm, Value::Null),
+                            Some(old) => (hm, Value::Option(Box::new(old))),
                         }
                     } else {
                         return Err(Interruption::TypeMismatch);
                     }
                 };
-                let ret = Value::Tuple(vector![hm.clone(), old]);
+                let hm = Value::Collection(Collection::HashMap(hm));
+                let ret = Value::Tuple(vector![hm, old]);
                 core.cont = Cont::Value(ret);
                 Ok(Step {})
             } else {

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -519,6 +519,23 @@ fn pattern_matches(env: &Env, pat: &Pat, v: &Value) -> Option<Env> {
             };
             pattern_matches(env, &*pat_.0, &*v_)
         }
+        (Pat::Tuple(ps), Value::Tuple(vs)) => {
+            if ps.vec.len() != vs.len() {
+                None
+            } else {
+                let mut env = env.clone();
+                for i in 0..ps.vec.len() {
+                    if let Some(env_) =
+                        pattern_matches(&env, &*ps.vec.get(i).unwrap().0, vs.get(i).unwrap())
+                    {
+                        env = env_
+                    } else {
+                        return None;
+                    }
+                }
+                Some(env)
+            }
+        }
         _ => None,
     }
 }

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -358,8 +358,27 @@ mod collection {
                 Err(Interruption::TypeMismatch)
             }
         }
-        pub fn get(_core: &mut Core, _v: Value) -> Result<Step, Interruption> {
-            nyi!(line!())
+        pub fn get(core: &mut Core, v: Value) -> Result<Step, Interruption> {
+            if let Some(env) =
+                pattern_matches(&core.env, &pattern::vars(core, vector!["hm", "k"]), &v)
+            {
+                let hm = env.get("hm").unwrap();
+                let k = env.get("k").unwrap();
+                let ret = {
+                    if let Value::Collection(Collection::HashMap(hm)) = hm {
+                        match hm.get(k) {
+                            None => Value::Null,
+                            Some(v) => Value::Option(Box::new(v.clone())),
+                        }
+                    } else {
+                        return Err(Interruption::TypeMismatch);
+                    }
+                };
+                core.cont = Cont::Value(ret);
+                Ok(Step {})
+            } else {
+                Err(Interruption::TypeMismatch)
+            }
         }
     }
 }

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -220,6 +220,7 @@ pub enum Interruption {
     SyntaxError(SyntaxError),
     ValueError(ValueError),
     UnboundIdentifer(Identifier),
+    UnrecognizedPrim(String),
     BlockedAwaiting,
     Limit(Limit),
     DivideByZero,

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -252,6 +252,12 @@ fn prim_debug_print() {
 }
 
 #[test]
+fn prim_collection_hashmap() {
+    let p = "let hm = prim \"hashMapNew\" (); let hm2 = prim \"hashMapPut\" (hm, 1, 2); let hm3 = prim \"hashMapPut\" (hm2.0, 2, 3); (hm, hm2, hm3)";
+    assert_(p, p)
+}
+
+#[test]
 fn function_call_return_restores_env() {
     assert_("func f() { }; let x = 0; x", "0");
     assert_("func f() { }; let x = 0; f(); x", "0");

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -11,10 +11,7 @@ fn assert_is_value(v: &str) {
 #[test]
 fn vm_literals() {
     assert_is_value("1");
-    assert_is_value("1.");
     assert_is_value("1_000");
-    assert_is_value("1e3");
-    assert_is_value("1_2.3_4e5_6");
     assert_is_value("0x123abcDEF");
     assert_("0xff", "255");
     // TODO: equality between different numeric types
@@ -25,6 +22,12 @@ fn vm_literals() {
 
     assert_is_value("#apple");
     assert_is_value("#apple(1)");
+
+    if false {
+        assert_is_value("1e3");
+        assert_is_value("1.");
+        assert_is_value("1_2.3_4e5_6");
+    }
 }
 
 #[test]

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -257,7 +257,18 @@ fn prim_debug_print() {
 #[test]
 fn prim_collection_hashmap() {
     let p = "let hm = prim \"hashMapNew\" (); let hm2 = prim \"hashMapPut\" (hm, 1, 2); let hm3 = prim \"hashMapPut\" (hm2.0, 2, 3); (hm, hm2, hm3)";
-    assert_(p, p)
+    assert_(p, p);
+
+    assert_(
+        "let (hm, old) = prim \"hashMapPut\" (prim \"hashMapNew\" (), 1, 2); old",
+        "null",
+    );
+
+    assert_("let (hm, _) = prim \"hashMapPut\" (prim \"hashMapNew\" (), 1, 2); prim \"hashMapGet\" (hm, 1)",
+           "?2");
+
+    assert_("let (hm, _) = prim \"hashMapPut\" (prim \"hashMapNew\" (), 1, 2); (prim \"hashMapPut\" (hm, 1, 3)).1",
+           "?2")
 }
 
 #[test]


### PR DESCRIPTION
Introduces three new `prim` functions, with these forms:
 - `hashMapNew : () -> M<_,_>` 
 - `hashMapPut : (M<K, V>, K, V) -> (M<K, V>, ?V)`
 - `hashMapGet : (M<K, V>, K) -> ?V`
 
Notes: 
 
1. We write type signatures above as if the key and value types must be fixed, but the hashmap does not enforce that.  It's okay to mix the dynamic types of keys, and values, in a heterogeneous way that static Motoko does not permit.  For instance, it's okay to have one map where `1` and `"one"` are each keys; also, they are distinct (key) values.

1. The `put` function is functional, in the sense that it returns the new map, as well as any old value at the put key.

1. Because `put` is functional, putting into a map does not affect the other versions, ever.  To get that mutable-sharing behavior, use these primitives to create an object, similar to how class `TrieMap` does for that for the `Trie` module in `base`.