### PR TITLE
VM: Special `FastRandIter` collection

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,4 +1,3 @@
-#![feature(inherent_associated_types)]
 pub mod ast;
 pub mod ast_traversal;
 pub mod check;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,3 +1,4 @@
+#![feature(inherent_associated_types)]
 pub mod ast;
 pub mod ast_traversal;
 pub mod check;

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -79,7 +79,6 @@ pub struct FastRandIter {
 }
 
 impl FastRandIter {
-    type Item = Value;
     pub fn new(size: Option<u32>, seed: u32) -> FastRandIter {
         FastRandIter {
             size,
@@ -235,7 +234,9 @@ impl Value {
                         .map(|(k, v)| Ok(Array(vec![k.json_value()?, v.json_value()?])))
                         .collect::<Result<Vec<_>, _>>()?,
                 ),
-                FastRandIter => Err(ValueError::NotConvertible("FastRandIter".to_string()))?,
+                Collection::FastRandIter(..) => {
+                    Err(ValueError::NotConvertible("FastRandIter".to_string()))?
+                }
             },
         })
     }

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -346,11 +346,11 @@ mod collection {
                 &pattern::vars(core, vector!["seed", "size"]),
                 &v,
             ) {
-                let seed: BigUint = env.get("seed").unwrap().convert()?; // or else TypeMismatch
-                let size: Option<BigUint> = env.get("size").unwrap().convert()?; // or else TypeMismatch
+                let seed: u32 = env.get("seed").unwrap().convert().map_err(Interruption::ValueError)?; // or else TypeMismatch
+                let size: Option<u32> = env.get("size").unwrap().convert().map_err(Interruption::ValueError)?; // or else TypeMismatch
                 // todo targs -- determine the type of values we are randomly producing.
                 core.cont = Cont::Value(Value::Collection(Collection::FastRandIter(
-                    FastRandIter::new(seed, size),
+                    FastRandIter::new(size, seed),
                 )));
                 Ok(Step {})
             } else {

--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -346,18 +346,13 @@ mod collection {
                 &pattern::vars(core, vector!["seed", "size"]),
                 &v,
             ) {
-                let seed = env.get("seed").unwrap();
-                let size = env.get("size").unwrap();
-                // todo -- conversion into Rust Option<u32>
-                if let (Value::Nat(seed), Value::Nat(size)) = (seed, size) {
-                    // todo targs -- determine the type of values we are randomly producing.
-                    core.cont = Cont::Value(Value::Collection(Collection::FastRandIter(
-                        FastRandIter::new(seed, size),
-                    )));
-                    Ok(Step {})
-                } else {
-                    Err(Interruption::TypeMismatch)
-                }
+                let seed: BigUint = env.get("seed").unwrap().convert()?; // or else TypeMismatch
+                let size: Option<BigUint> = env.get("size").unwrap().convert()?; // or else TypeMismatch
+                // todo targs -- determine the type of values we are randomly producing.
+                core.cont = Cont::Value(Value::Collection(Collection::FastRandIter(
+                    FastRandIter::new(seed, size),
+                )));
+                Ok(Step {})
             } else {
                 Err(Interruption::TypeMismatch)
             }

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -274,6 +274,14 @@ fn prim_collection_hashmap() {
 }
 
 #[test]
+fn fastranditer() {
+    assert_(
+        "var i = prim \"fastRandIterNew\" (33, null); (prim \"fastRandIterNext\" i).0",
+        "?1592943",
+    );
+}
+
+#[test]
 fn function_call_return_restores_env() {
     assert_("func f() { }; let x = 0; x", "0");
     assert_("func f() { }; let x = 0; f(); x", "0");


### PR DESCRIPTION
Exposing VM-specific primitives for performance tests:
- `FastRandIterNew`
- `FastRandIterNext`

See also https://github.com/dfinity/canister-profiling/blob/7a2cbae2e8bb2db653ab9ac52ba03ac8070aaf95/collections/rust/src/hashmap/src/lib.rs#L9