### PR TITLE
Add pattern matching shorthand functions to `Value`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -185,109 +185,109 @@ impl Value {
             Literal::Blob(v) => Blob(v),
         })
     }
- 
-    pub fn as_bool(self) -> Option<bool> {
+
+    pub fn to_bool(self) -> Option<bool> {
         match self {
             Value::Bool(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_nat(self) -> Option<BigUint> {
+    pub fn to_nat(self) -> Option<BigUint> {
         match self {
             Value::Nat(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_int(self) -> Option<BigInt> {
+    pub fn to_int(self) -> Option<BigInt> {
         match self {
             Value::Int(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_float(self) -> Option<f64> {
+    pub fn to_float(self) -> Option<f64> {
         match self {
             Value::Float(x) => Some(x.0),
             _ => None,
         }
     }
-    pub fn as_char(self) -> Option<char> {
+    pub fn to_char(self) -> Option<char> {
         match self {
             Value::Char(x) => Some(x),
             // Value::Text(x)=>Some(x.0.),
             _ => None,
         }
     }
-    pub fn as_text(self) -> Option<Text> {
+    pub fn to_text(self) -> Option<Text> {
         match self {
             Value::Text(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_string(self) -> Option<String> {
-        Some(self.as_text()?.to_string())
+    pub fn to_string(self) -> Option<String> {
+        Some(self.to_text()?.to_string())
     }
-    pub fn as_blob(self) -> Option<Vec<u8>> {
+    pub fn to_blob(self) -> Option<Vec<u8>> {
         match self {
             Value::Blob(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_array(self) -> Option<Vector<Value>> {
+    pub fn to_array(self) -> Option<Vector<Value>> {
         match self {
             Value::Array(_, x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_tuple(self) -> Option<Vector<Value>> {
+    pub fn to_tuple(self) -> Option<Vector<Value>> {
         match self {
             Value::Tuple(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_object(self) -> Option<HashMap<Id, Value>> {
+    pub fn to_object(self) -> Option<HashMap<Id, Value>> {
         match self {
             Value::Object(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_option(self) -> Option<Value> {
+    pub fn to_option(self) -> Option<Value> {
         match self {
             Value::Null => Some(Value::Null),
             Value::Option(x) => Some(*x),
             _ => None,
         }
     }
-    pub fn as_variant(self) -> Option<(String, Option<Value>)> {
+    pub fn to_variant(self) -> Option<(String, Option<Value>)> {
         match self {
-            Value::Variant(x, y) => Some((*x.0, *y)),
+            Value::Variant(x, y) => Some((*x.0, y.map(Box::unbo))),
             _ => None,
         }
     }
-    pub fn as_pointer(self) -> Option<Pointer> {
+    pub fn to_pointer(self) -> Option<Pointer> {
         match self {
             Value::Pointer(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_array_offset(self) -> Option<(Pointer, usize)> {
+    pub fn to_array_offset(self) -> Option<(Pointer, usize)> {
         match self {
             Value::ArrayOffset(x, y) => Some((x, y)),
             _ => None,
         }
     }
-    pub fn as_function(self) -> Option<ClosedFunction> {
+    pub fn to_function(self) -> Option<ClosedFunction> {
         match self {
             Value::Function(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_prim_function(self) -> Option<PrimFunction> {
+    pub fn to_prim_function(self) -> Option<PrimFunction> {
         match self {
             Value::PrimFunction(x) => Some(x),
             _ => None,
         }
     }
-    pub fn as_collection(self) -> Option<Collection> {
+    pub fn to_collection(self) -> Option<Collection> {
         match self {
             Value::Collection(x) => Some(x),
             _ => None,

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -4,7 +4,7 @@ use crate::vm_types::Env;
 use im_rc::vector;
 use im_rc::HashMap;
 use im_rc::Vector;
-use num_bigint::{BigInt, BigUint};
+use num_bigint::{BigInt, BigUint, ToBigInt};
 use num_traits::ToPrimitive;
 use ordered_float::OrderedFloat;
 use serde::de::DeserializeOwned;
@@ -194,12 +194,14 @@ impl Value {
     }
     pub fn to_nat(self) -> Option<BigUint> {
         match self {
+            Value::Int(x) => x.to_biguint(),
             Value::Nat(x) => Some(x),
             _ => None,
         }
     }
     pub fn to_int(self) -> Option<BigInt> {
         match self {
+            Value::Nat(x) => x.to_bigint(),
             Value::Int(x) => Some(x),
             _ => None,
         }
@@ -213,18 +215,16 @@ impl Value {
     pub fn to_char(self) -> Option<char> {
         match self {
             Value::Char(x) => Some(x),
-            // Value::Text(x)=>Some(x.0.),
+            // Value::Text(x) => x.0.get(0)?.chars().next(),
             _ => None,
         }
     }
     pub fn to_text(self) -> Option<Text> {
         match self {
+            // Value::Char(x) => Some(x),
             Value::Text(x) => Some(x),
             _ => None,
         }
-    }
-    pub fn to_string(self) -> Option<String> {
-        Some(self.to_text()?.to_string())
     }
     pub fn to_blob(self) -> Option<Vec<u8>> {
         match self {
@@ -244,7 +244,7 @@ impl Value {
             _ => None,
         }
     }
-    pub fn to_object(self) -> Option<HashMap<Id, Value>> {
+    pub fn to_object(self) -> Option<HashMap<Id, FieldValue>> {
         match self {
             Value::Object(x) => Some(x),
             _ => None,
@@ -259,7 +259,7 @@ impl Value {
     }
     pub fn to_variant(self) -> Option<(String, Option<Value>)> {
         match self {
-            Value::Variant(x, y) => Some((*x.0, y.map(Box::unbo))),
+            Value::Variant(x, y) => Some((*x.0, y.map(|y| *y))),
             _ => None,
         }
     }

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -185,9 +185,7 @@ impl Value {
             Literal::Blob(v) => Blob(v),
         })
     }
-}
-
-impl Value {
+ 
     pub fn as_bool(self) -> Option<bool> {
         match self {
             Value::Bool(x) => Some(x),

--- a/src/lib/value.rs
+++ b/src/lib/value.rs
@@ -149,6 +149,114 @@ impl Value {
 }
 
 impl Value {
+    pub fn as_bool(self) -> Option<bool> {
+        match self {
+            Value::Bool(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_nat(self) -> Option<BigUint> {
+        match self {
+            Value::Nat(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_int(self) -> Option<BigInt> {
+        match self {
+            Value::Int(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_float(self) -> Option<f64> {
+        match self {
+            Value::Float(x) => Some(x.0),
+            _ => None,
+        }
+    }
+    pub fn as_char(self) -> Option<char> {
+        match self {
+            Value::Char(x) => Some(x),
+            // Value::Text(x)=>Some(x.0.),
+            _ => None,
+        }
+    }
+    pub fn as_text(self) -> Option<Text> {
+        match self {
+            Value::Text(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_string(self) -> Option<String> {
+        Some(self.as_text()?.to_string())
+    }
+    pub fn as_blob(self) -> Option<Vec<u8>> {
+        match self {
+            Value::Blob(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_array(self) -> Option<Vector<Value>> {
+        match self {
+            Value::Array(_, x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_tuple(self) -> Option<Vector<Value>> {
+        match self {
+            Value::Tuple(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_object(self) -> Option<HashMap<Id, Value>> {
+        match self {
+            Value::Object(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_option(self) -> Option<Value> {
+        match self {
+            Value::Null => Some(Value::Null),
+            Value::Option(x) => Some(*x),
+            _ => None,
+        }
+    }
+    pub fn as_variant(self) -> Option<(String, Option<Value>)> {
+        match self {
+            Value::Variant(x, y) => Some((*x.0, *y)),
+            _ => None,
+        }
+    }
+    pub fn as_pointer(self) -> Option<Pointer> {
+        match self {
+            Value::Pointer(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_array_offset(self) -> Option<(Pointer, usize)> {
+        match self {
+            Value::ArrayOffset(x, y) => Some((x, y)),
+            _ => None,
+        }
+    }
+    pub fn as_function(self) -> Option<ClosedFunction> {
+        match self {
+            Value::Function(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_prim_function(self) -> Option<PrimFunction> {
+        match self {
+            Value::PrimFunction(x) => Some(x),
+            _ => None,
+        }
+    }
+    pub fn as_collection(self) -> Option<Collection> {
+        match self {
+            Value::Collection(x) => Some(x),
+            _ => None,
+        }
+    }
+
     /// Create a JSON-style representation of the Motoko value.
     pub fn json_value(&self) -> Result<serde_json::Value, ValueError> {
         use serde_json::json;


### PR DESCRIPTION
Includes high-performance `Value.to_nat()`, `Value.to_array()`, etc. functions for unwrapping a `Value` as an alternative to using the (slightly slower) `Value.convert()` function. 