### PR TITLE
Benchmark `Value.convert()` function for u32 values

### DIFF
--- a/benches/bench_convert.rs
+++ b/benches/bench_convert.rs
@@ -40,7 +40,7 @@ thread_local! {
 }
 
 #[bench]
-fn match_nat(b: &mut Bencher) {
+fn match_u32(b: &mut Bencher) {
     b.iter(|| {
         RAND.with(|rand| {
             let mut rand = rand.borrow_mut();
@@ -60,7 +60,7 @@ fn match_nat(b: &mut Bencher) {
 }
 
 #[bench]
-fn match_nat_clone(b: &mut Bencher) {
+fn match_u32_clone(b: &mut Bencher) {
     b.iter(|| {
         RAND.with(|rand| {
             let mut rand = rand.borrow_mut();
@@ -80,7 +80,7 @@ fn match_nat_clone(b: &mut Bencher) {
 }
 
 #[bench]
-fn convert_nat(b: &mut Bencher) {
+fn convert_u32(b: &mut Bencher) {
     b.iter(|| {
         RAND.with(|rand| {
             let mut rand = rand.borrow_mut();

--- a/benches/bench_convert.rs
+++ b/benches/bench_convert.rs
@@ -1,0 +1,93 @@
+#![feature(test)]
+extern crate test;
+use num_bigint::ToBigUint;
+use test::Bencher;
+
+use motoko::value::Value;
+use num_traits::ToPrimitive;
+use std::cell::RefCell;
+
+struct Random {
+    state: u32,
+    size: Option<u32>,
+    ind: u32,
+}
+impl Random {
+    pub fn new(size: Option<u32>, seed: u32) -> Self {
+        Random {
+            state: seed,
+            size,
+            ind: 0,
+        }
+    }
+}
+impl Iterator for Random {
+    type Item = u32;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(size) = self.size {
+            self.ind += 1;
+            if self.ind > size {
+                return None;
+            }
+        }
+        self.state = self.state * 48271 % 0x7fffffff;
+        Some(self.state)
+    }
+}
+
+thread_local! {
+    static RAND: RefCell<Random>  = RefCell::new(Random::new(None, 42));
+}
+
+#[bench]
+fn match_nat(b: &mut Bencher) {
+    b.iter(|| {
+        RAND.with(|rand| {
+            let mut rand = rand.borrow_mut();
+
+            let value = Value::Nat(rand.next().unwrap().to_biguint().unwrap());
+
+            match value {
+                Value::Nat(n) => Some(n),
+                Value::Int(n) => n.to_biguint(),
+                _ => None,
+            }
+            .unwrap()
+            .to_u32()
+            .unwrap()
+        });
+    })
+}
+
+#[bench]
+fn match_nat_clone(b: &mut Bencher) {
+    b.iter(|| {
+        RAND.with(|rand| {
+            let mut rand = rand.borrow_mut();
+
+            let value = &Value::Nat(rand.next().unwrap().to_biguint().unwrap());
+
+            match value.clone() {
+                Value::Nat(n) => Some(n),
+                Value::Int(n) => n.to_biguint(),
+                _ => None,
+            }
+            .unwrap()
+            .to_u32()
+            .unwrap()
+        });
+    })
+}
+
+#[bench]
+fn convert_nat(b: &mut Bencher) {
+    b.iter(|| {
+        RAND.with(|rand| {
+            let mut rand = rand.borrow_mut();
+
+            let value = &Value::Nat(rand.next().unwrap().to_biguint().unwrap());
+
+            value.convert::<u32>().unwrap()
+        });
+    })
+}


### PR DESCRIPTION
```
test convert_u32     ... bench:          87 ns/iter (+/- 2)
test match_u32       ... bench:          77 ns/iter (+/- 2)
test match_u32_clone ... bench:         155 ns/iter (+/- 25)
```