### PR TITLE
More polished `Core.eval` API

### DIFF
--- a/src/lib/vm.rs
+++ b/src/lib/vm.rs
@@ -1375,9 +1375,56 @@ impl Core {
         core_init(prog)
     }
 
+    /// New VM core without any program.
+    pub fn empty() -> Self {
+        let mut core = core_init(crate::ast::Delim::new());
+        core.eval_(None, &Limits::none()).expect("empty");
+        core
+    }
+
+    /// New VM core from a given program string, to be parsed during Core construction.
+    pub fn from_str(s: &str) -> Result<Self, crate::parser_types::SyntaxError> {
+        Ok(core_init(crate::check::parse(s)?))
+    }
+
     /// Step VM core, under some limits.
     pub fn step(&mut self, limits: &Limits) -> Result<Step, Interruption> {
         core_step(self, limits)
+    }
+
+    /// Evaluate a new program fragment, assuming `Core` is in a
+    /// well-defined "done" state.
+    pub fn eval(&mut self, new_prog_frag: &str) -> Result<Value, Interruption> {
+        self.eval_(Some(new_prog_frag), &Limits::none())
+    }
+
+    /// Evaluate current continuation, or optionally a new program
+    /// fragment, assuming `Core` is in a well-defined "done" state.
+    pub fn eval_(
+        &mut self,
+        new_prog_frag: Option<&str>,
+        limits: &Limits,
+    ) -> Result<Value, Interruption> {
+        if let Some(new_prog_frag) = new_prog_frag {
+            use crate::vm_types::EvalInitError;
+            if self.stack.len() > 0 {
+                return Err(Interruption::EvalInitError(EvalInitError::NonEmptyStack));
+            }
+            match self.cont {
+                Cont::Value(_) => {}
+                _ => return Err(Interruption::EvalInitError(EvalInitError::NonValueCont)),
+            };
+            let p = crate::check::parse(&new_prog_frag).map_err(Interruption::SyntaxError)?;
+            self.cont = Cont::Decs(Vector::from(p.vec));
+        } else {
+        };
+        loop {
+            match self.step(limits) {
+                Ok(_step) => {}
+                Err(Interruption::Done(v)) => return Ok(v),
+                Err(other_interruption) => return Err(other_interruption),
+            }
+        }
     }
 }
 

--- a/src/lib/vm_types.rs
+++ b/src/lib/vm_types.rs
@@ -232,6 +232,14 @@ pub enum Interruption {
     NotYetImplemented(NYI),
     Unknown,
     Impossible,
+    EvalInitError(EvalInitError),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "evaliniterror_type", content = "value")]
+pub enum EvalInitError {
+    NonEmptyStack,
+    NonValueCont,
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, Deserialize)]

--- a/tests/test_vm.rs
+++ b/tests/test_vm.rs
@@ -374,3 +374,15 @@ f()
 "#;
     assert_(prog, "666");
 }
+
+#[test]
+fn test_core_eval() {
+    let mut core = motoko::vm_types::Core::empty();
+    core.eval("var x = 1").expect("oops");
+    core.eval("var y = x + 1").expect("oops");
+    let y = core.eval("y").expect("oops");
+    assert_eq!(
+        y,
+        motoko::value::Value::Nat(num_bigint::BigUint::from(2 as u32))
+    )
+}


### PR DESCRIPTION
In this PR, `Core.eval` exists and is somewhat nice to use.
- `eval` takes a string (parses it internally, exposes syntax errors are interruptions).
- `eval` assumes the intention is to run completely, without any `Limits` (the common case).
- `eval` returns a `Result<Value, Interruption>` where `Value` is the common case.
- This form is now a specialized form of `Core.eval_`, which can be used to run the residual program, if any.  Unlike the minimal form `Core.eval`, this less minimal form accepts `Limits`.