### PR TITLE
Oopsie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/motoko"
 repository = "https://github.com/dfinity/motoko.rs"
 categories = ["wasm"]
 keywords = ["internet-computer", "motoko", "wasm"]
-include = ["src", "Cargo.toml", "LICENSE", "README.md"]
+include = ["src", "build.rs", "Cargo.toml", "LICENSE", "README.md"]
 
 [build-dependencies]
 lalrpop = "0.19.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.13"
+version = "0.0.14"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
#87 goofed the Cargo.toml file so that it didn't ship a build script that is required.

This PR tries to fix it.