### PR TITLE
cargo toml

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.14"
+version = "0.0.15"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/README.md
+++ b/crates/motoko/README.md
@@ -1,0 +1,3 @@
+# Motoko crate
+
+

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -17,7 +17,7 @@ name = "motoko_proc_macro"
 proc-macro = true
 
 [dependencies]
-motoko = { path = "../motoko" }
+motoko = { path = "../motoko", version = "0.0.14" }
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.14"
+version = "0.0.15"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ name = "motoko_proc_macro"
 proc-macro = true
 
 [dependencies]
-motoko = { path = "../motoko", version = "0.0.14" }
+motoko = { path = "../motoko", version = "0.0.15" }
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"


### PR DESCRIPTION
- published https://crates.io/crates/motoko_proc_macro initial version 0.0.15
- published accompanying https://crates.io/crates/motoko/ version 0.0.15

The last PR, #91 reorganised the repo, but failed to create new READMEs for the sub-workspace crates.

This PR creates minimal READMEs to satisfy the `cargo publish` checklist for our Cargo.toml files, but they should be revised and expanded.