### PR TITLE
Remove 'value-reflection' and 'core-reflection' from default features

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -21,7 +21,7 @@ lalrpop-util = "0.19.8"
 regex = "1.6.0"
 env_logger = "0.9.0"
 log = "0.4.17"
-structopt = { version = "0.3.26", optional = true }
+structopt = { version = "0.3.26" }
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-traits = "0.2.15"
 ordered-float = { version = "3.0.0", features = ["serde"] }
@@ -54,8 +54,10 @@ path = "src/bin/mo.rs"
 required-features = ["exe"]
 
 [features]
-default = ["exe", "parser", "to-motoko", "value-reflection", "core-reflection"]
-exe = ["structopt"]
+default = ["parser", "to-motoko"]
+reflection = ["value-reflection", "core-reflection"]
+
+exe = []
 serde-paths = ["serde_path_to_error"]
 parser = []
 to-motoko = []

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -243,7 +243,7 @@ fn call_prim_function(
         }
         #[cfg(feature = "value-reflection")]
         ReflectValue => {
-            core.cont = Cont::Value(args.to_rust::<Value>().map_err(Interruption::ValueError)?);
+            // core.cont = Cont::Value(args.to_rust::<Value>().map_err(Interruption::ValueError)?);
             Ok(Step {})
         }
         #[cfg(feature = "to-motoko")]

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -17,7 +17,7 @@ name = "motoko_proc_macro"
 proc-macro = true
 
 [dependencies]
-motoko = { path = "../motoko", version = "0.0.15" }
+motoko = { path = "../motoko", version = "0.0.15", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -17,6 +17,8 @@ name = "motoko_proc_macro"
 proc-macro = true
 
 [dependencies]
+# TODO: set this up as a "workspace dependency"? 
+# https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
 motoko = { path = "../motoko", version = "0.0.15", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"

--- a/crates/motoko_proc_macro/src/lib.rs
+++ b/crates/motoko_proc_macro/src/lib.rs
@@ -12,14 +12,16 @@ pub fn parse_static(input: TokenStream) -> TokenStream {
     )
 }
 
-#[proc_macro]
-pub fn eval_static(input: TokenStream) -> TokenStream {
-    let input = get_input_string(input);
-    expand_static(
-        &motoko::vm::eval(&input).expect("Evaluation error"),
-        "::motoko::value::Value",
-    )
-}
+// Temporarily removed due to possible confusion around the different set of feature flags
+
+// #[proc_macro]
+// pub fn eval_static(input: TokenStream) -> TokenStream {
+//     let input = get_input_string(input);
+//     expand_static(
+//         &motoko::vm::eval(&input).expect("Evaluation error"),
+//         "::motoko::value::Value",
+//     )
+// }
 
 fn expand_static<'de, T: Sized + serde::Serialize + serde::Deserialize<'de>>(
     value: &T,


### PR DESCRIPTION
Also adds a new 'reflection' feature to enable both of these together.