### PR TITLE
Fix: Avoid a per-step clone.

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.15"
+version = "0.0.17"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -1329,8 +1329,8 @@ fn core_step_(core: &mut Core) -> Result<Step, Interruption> {
     trace!("   - env = {:?}", core.env);
     trace!(" - stack = {:#?}", core.stack);
     trace!(" - store = {:#?}", core.store);
-    let cont = core.cont.clone(); // to do -- avoid clone here.
-    core.cont = Cont::Taken;
+    let mut cont = Cont::Taken;
+    std::mem::swap(&mut core.cont, &mut cont);
     match cont {
         Cont::Taken => unreachable!("The VM's logic currently has an internal issue."),
         Cont::Exp_(e, decs) => {

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 # TODO: set this up as a "workspace dependency"? 
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
-motoko = { path = "../motoko", version = "0.0.15", default-features = false, features = ["parser"] }
+motoko = { path = "../motoko", version = "0.0.17", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.15"
+version = "0.0.17"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
This PR avoids a single clone per step.  Since steps happen a lot to run a program, this should help a lot.

Still remaining:
- Many clones of `Value`s. (Would be better if the root of each was an `Rc<_>`)
- Many clones of `Source`s (Would be better to share, via `Rc<_>`)
- Some per-loop iteration clones for `for` and `while` loops, where we are forced to copy the `Box`-based AST to keep looping (without resorting references, another possible option to avoid cloning the continuation on loops).