### PR TITLE
Dynamic Rust values

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1.0.85"
 serde_path_to_error = { version = "0.1.8", optional = true }
 # serde_with = "2.0.1"
 test-log = "0.2.11"
+dyn-clone = "1.0.9"
 
 [lib]
 name = "motoko"

--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.17"
+version = "0.0.18"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -291,14 +291,8 @@ pub enum ResolvedImport {
     Prim,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
 pub struct Sugar(pub bool);
-
-impl Default for Sugar {
-    fn default() -> Self {
-        Sugar(false)
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum PrimType {

--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -406,7 +406,7 @@ pub enum Exp {
     Dot(Exp_, Id_),
     Assign(Exp_, Exp_),
     Array(Mut, Delim<Exp_>),
-    Idx(Exp_, Exp_),
+    Index(Exp_, Exp_),
     Function(Function),
     Call(Exp_, Option<Inst>, Exp_),
     Block(Delim<Dec_>),

--- a/crates/motoko/src/lib/ast_traversal.rs
+++ b/crates/motoko/src/lib/ast_traversal.rs
@@ -205,7 +205,7 @@ impl<'a> Traverse for Loc<&'a Exp> {
                 f(&e2.tree());
             }
             Exp::Array(_, es) => es.vec.iter().for_each(|e| f(&e.tree())),
-            Exp::Idx(e1, e2) => {
+            Exp::Index(e1, e2) => {
                 f(&e1.tree());
                 f(&e2.tree());
             }

--- a/crates/motoko/src/lib/dynamic.rs
+++ b/crates/motoko/src/lib/dynamic.rs
@@ -1,0 +1,26 @@
+use std::fmt::Debug;
+use std::rc::Rc;
+
+use crate::value::Value;
+
+pub use dyn_clone::DynClone;
+
+pub trait Dynamic: Debug + DynClone + DynHash {
+    fn get_index(&self, _index: &Value) -> Option<Rc<Value>> {
+        None
+    }
+
+    fn get_field(&self, _name: &str) -> Option<Rc<Value>> {
+        None
+    }
+}
+
+pub trait DynHash {
+    fn dyn_hash(&self, state: &mut dyn std::hash::Hasher);
+}
+
+impl<H: std::hash::Hash + ?Sized> DynHash for H {
+    fn dyn_hash(&self, mut state: &mut dyn std::hash::Hasher) {
+        self.hash(&mut state);
+    }
+}

--- a/crates/motoko/src/lib/format.rs
+++ b/crates/motoko/src/lib/format.rs
@@ -221,7 +221,7 @@ impl ToDoc for Exp {
             Dot(e, s) => e.doc().append(".").append(s.doc()),
             Assign(from, to) => from.doc().append(str(" := ")).append(to.doc()),
             Array(m, es) => array(m, es),
-            Idx(e, idx) => e.doc().append("[").append(idx.doc()).append("]"),
+            Index(e, idx) => e.doc().append("[").append(idx.doc()).append("]"),
             Function(_) => todo!(),
             Call(e, b, a) => e
                 .doc()

--- a/crates/motoko/src/lib/mod.rs
+++ b/crates/motoko/src/lib/mod.rs
@@ -3,6 +3,7 @@ pub mod ast_traversal;
 #[cfg(feature = "parser")]
 pub mod check;
 pub mod convert;
+pub mod dynamic;
 #[cfg(feature = "parser")]
 pub mod format;
 #[cfg(feature = "parser")]

--- a/crates/motoko/src/lib/serde_utils.rs
+++ b/crates/motoko/src/lib/serde_utils.rs
@@ -57,3 +57,17 @@ pub mod im_rc_hashmap {
         Ok(attr.into_iter().collect())
     }
 }
+
+pub mod box_dynamic {
+    // use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use crate::value::Dynamic;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(map: &Box<dyn Dynamic>, ser: S) -> Result<S::Ok, S::Error> {
+        todo!()
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(des: D) -> Result<Box<dyn Dynamic>, D::Error> {
+        todo!()
+    }
+}

--- a/crates/motoko/src/lib/serde_utils.rs
+++ b/crates/motoko/src/lib/serde_utils.rs
@@ -60,14 +60,14 @@ pub mod im_rc_hashmap {
 
 pub mod box_dynamic {
     // use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use crate::value::Dynamic;
+    use crate::dynamic::Dynamic;
     use serde::{Deserializer, Serializer};
 
-    pub fn serialize<S: Serializer>(map: &Box<dyn Dynamic>, ser: S) -> Result<S::Ok, S::Error> {
+    pub fn serialize<S: Serializer>(_map: &Box<dyn Dynamic>, _ser: S) -> Result<S::Ok, S::Error> {
         todo!()
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(des: D) -> Result<Box<dyn Dynamic>, D::Error> {
+    pub fn deserialize<'de, D: Deserializer<'de>>(_des: D) -> Result<Box<dyn Dynamic>, D::Error> {
         todo!()
     }
 }

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 use std::num::Wrapping;
-use std::rc::Rc;
 
 use crate::ast::{Dec, Decs, Exp, Function, Id, Literal, Mut};
+use crate::dynamic::Dynamic;
 use crate::vm_types::Env;
 
 use im_rc::HashMap;
@@ -85,7 +85,6 @@ pub struct ClosedFunction(pub Closed<Function>);
 pub type Float = OrderedFloat<f64>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-// #[serde(tag = "value_type", content = "value")]
 pub enum Value {
     Null,
     Bool(bool),
@@ -119,32 +118,15 @@ impl Clone for DynamicValue {
 }
 
 impl PartialEq for DynamicValue {
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, _other: &Self) -> bool {
         todo!()
     }
 }
-
 impl Eq for DynamicValue {}
 
 impl std::hash::Hash for DynamicValue {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.dyn_hash(state)
-    }
-}
-
-pub trait Dynamic: std::fmt::Debug + dyn_clone::DynClone + DynHash {
-    fn get_index(&self, _index: &Value) -> Option<Rc<Value>> {
-        None
-    }
-}
-
-pub trait DynHash {
-    fn dyn_hash(&self, state: &mut dyn std::hash::Hasher);
-}
-
-impl<H: std::hash::Hash + ?Sized> DynHash for H {
-    fn dyn_hash(&self, mut state: &mut dyn std::hash::Hasher) {
-        self.hash(&mut state);
     }
 }
 

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -109,14 +109,8 @@ pub enum Value {
     Dynamic(DynamicValue),
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DynamicValue(#[serde(with = "crate::serde_utils::box_dynamic")] pub Box<dyn Dynamic>);
-
-impl std::fmt::Debug for DynamicValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        todo!()
-    }
-}
 
 impl Clone for DynamicValue {
     fn clone(&self) -> Self {
@@ -134,13 +128,23 @@ impl Eq for DynamicValue {}
 
 impl std::hash::Hash for DynamicValue {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        todo!()
+        self.0.dyn_hash(state)
     }
 }
 
-pub trait Dynamic: dyn_clone::DynClone {
-    fn get_index(&self, index: &Value) -> Option<Rc<Value>> {
+pub trait Dynamic: std::fmt::Debug + dyn_clone::DynClone + DynHash {
+    fn get_index(&self, _index: &Value) -> Option<Rc<Value>> {
         None
+    }
+}
+
+pub trait DynHash {
+    fn dyn_hash(&self, state: &mut dyn std::hash::Hasher);
+}
+
+impl<H: std::hash::Hash + ?Sized> DynHash for H {
+    fn dyn_hash(&self, mut state: &mut dyn std::hash::Hasher) {
+        self.hash(&mut state);
     }
 }
 

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -152,19 +152,21 @@ fn relop(
 ) -> Result<Value, Interruption> {
     use RelOp::*;
     use Value::*;
-    match relop {
+    Ok(Bool(match relop {
         Eq => match (v1, v2) {
-            (Nat(n1), Nat(n2)) => Ok(Bool(n1 == n2)),
-            (Int(i1), Int(i2)) => Ok(Bool(i1 == i2)),
-            _ => nyi!(line!()),
+            (Bool(a), Bool(b)) => a == b,
+            (Nat(n1), Nat(n2)) => n1 == n2,
+            (Int(i1), Int(i2)) => i1 == i2,
+            _ => nyi!(line!())?,
         },
         Neq => match (v1, v2) {
-            (Nat(n1), Nat(n2)) => Ok(Bool(n1 != n2)),
-            (Int(i1), Int(i2)) => Ok(Bool(i1 != i2)),
-            _ => nyi!(line!()),
+            (Bool(a), Bool(b)) => a != b,
+            (Nat(n1), Nat(n2)) => n1 != n2,
+            (Int(i1), Int(i2)) => i1 != i2,
+            _ => nyi!(line!())?,
         },
-        _ => nyi!(line!()),
-    }
+        _ => nyi!(line!())?,
+    }))
 }
 
 fn exp_conts_(
@@ -1166,6 +1168,14 @@ fn stack_cont(core: &mut Core, v: Value) -> Result<Step, Interruption> {
                 Value::Object(fs) => {
                     if let Some(f) = fs.get(&*f.0) {
                         core.cont = Cont::Value(f.val.clone());
+                        Ok(Step {})
+                    } else {
+                        Err(Interruption::TypeMismatch)
+                    }
+                }
+                Value::Dynamic(d) => {
+                    if let Some(f) = d.0.get_field(&*f.0) {
+                        core.cont = Cont::Value((*f).clone());
                         Ok(Step {})
                     } else {
                         Err(Interruption::TypeMismatch)

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -154,13 +154,15 @@ fn relop(
     use Value::*;
     Ok(Bool(match relop {
         Eq => match (v1, v2) {
-            (Bool(a), Bool(b)) => a == b,
+            (Bool(b1), Bool(b2)) => b1 == b2,
+            (Text(t1), Text(t2)) => t1.to_string() == t2.to_string(),
             (Nat(n1), Nat(n2)) => n1 == n2,
             (Int(i1), Int(i2)) => i1 == i2,
             _ => nyi!(line!())?,
         },
         Neq => match (v1, v2) {
-            (Bool(a), Bool(b)) => a != b,
+            (Bool(b1), Bool(b2)) => b1 != b2,
+            (Text(t1), Text(t2)) => t1.to_string() == t2.to_string(),
             (Nat(n1), Nat(n2)) => n1 != n2,
             (Int(i1), Int(i2)) => i1 != i2,
             _ => nyi!(line!())?,
@@ -985,7 +987,7 @@ fn stack_cont(core: &mut Core, v: Value) -> Result<Step, Interruption> {
                             core.cont = Cont::Value(Value::ArrayOffset(p, i));
                             Ok(Step {})
                         }
-                        (Value::Dynamic(d), v) => {
+                        (Value::Dynamic(_), v) => {
                             core.cont = Cont::Value(v);
                             Ok(Step {})
                         }

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -1,14 +1,14 @@
 use num_bigint::ToBigUint;
-use std::{collections::HashMap, rc::Rc};
+use std::rc::Rc;
 
 use motoko::value::Text;
 use motoko::value::{Dynamic, DynamicValue, Value};
 
 #[test]
 fn get_index() {
-    #[derive(Debug, Clone)]
+    #[derive(Clone, Debug, Hash, Default)]
     struct Struct {
-        pub map: HashMap<Value, Rc<Value>>,
+        pub map: im_rc::HashMap<Value, Rc<Value>>,
     }
 
     impl Dynamic for Struct {
@@ -21,7 +21,7 @@ fn get_index() {
     let expected = Rc::new(Value::Text(Text::from("expected")));
     let value = Value::Dynamic(DynamicValue(Box::new({
         let mut s = Struct {
-            map: HashMap::new(),
+            map: Default::default(),
         };
         s.map
             .insert(Value::Nat(5.to_biguint().unwrap()), expected.clone());

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -1,0 +1,38 @@
+use num_bigint::ToBigUint;
+use std::{collections::HashMap, rc::Rc};
+
+use motoko::value::Text;
+use motoko::value::{Dynamic, DynamicValue, Value};
+
+#[test]
+fn get_index() {
+    #[derive(Debug, Clone)]
+    struct Struct {
+        pub map: HashMap<Value, Rc<Value>>,
+    }
+
+    impl Dynamic for Struct {
+        fn get_index(&self, index: &Value) -> Option<Rc<Value>> {
+            println!("Index: {:?}", index);
+            self.map.get(index).map(Clone::clone)
+        }
+    }
+
+    let expected = Rc::new(Value::Text(Text::from("expected")));
+    let value = Value::Dynamic(DynamicValue(Box::new({
+        let mut s = Struct {
+            map: HashMap::new(),
+        };
+        s.map
+            .insert(Value::Nat(5.to_biguint().unwrap()), expected.clone());
+        s
+    })));
+
+    let mut core = motoko::vm_types::Core::empty();
+    core.env.insert("value".to_string(), value);
+
+    assert_eq!(
+        core.eval_prog(motoko::check::parse("value[5]").unwrap()),
+        Ok((*expected).clone())
+    );
+}

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -1,11 +1,12 @@
+use motoko::dynamic::Dynamic;
 use num_bigint::ToBigUint;
 use std::rc::Rc;
 
 use motoko::value::Text;
-use motoko::value::{Dynamic, DynamicValue, Value};
+use motoko::value::{DynamicValue, Value};
 
 #[test]
-fn get_index() {
+fn dyn_struct() {
     #[derive(Clone, Debug, Hash, Default)]
     struct Struct {
         pub map: im_rc::HashMap<Value, Rc<Value>>,
@@ -15,6 +16,13 @@ fn get_index() {
         fn get_index(&self, index: &Value) -> Option<Rc<Value>> {
             println!("Index: {:?}", index);
             self.map.get(index).map(Clone::clone)
+        }
+
+        fn get_field(&self, name: &str) -> Option<Rc<Value>> {
+            match name {
+                "x" => Some(Rc::new(Value::Text(Text::from("expected")))),
+                _ => None,
+            }
         }
     }
 
@@ -32,7 +40,7 @@ fn get_index() {
     core.env.insert("value".to_string(), value);
 
     assert_eq!(
-        core.eval_prog(motoko::check::parse("value[5]").unwrap()),
-        Ok((*expected).clone())
+        core.eval_prog(motoko::check::parse("value[5] == value.x").unwrap()),
+        Ok((Value::Bool(true)).clone())
     );
 }

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 # TODO: set this up as a "workspace dependency"? 
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
-motoko = { path = "../motoko", version = "0.0.17", default-features = false, features = ["parser"] }
+motoko = { path = "../motoko", version = "0.0.18", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.17"
+version = "0.0.18"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
This feature makes it possible to use Rust values directly in Motoko (without serialization) by implementing the `motoko::value::Dynamic` trait. 