### PR TITLE
Add thread-local shared primitive values

### DIFF
--- a/crates/motoko/benches/bench_core.rs
+++ b/crates/motoko/benches/bench_core.rs
@@ -27,7 +27,7 @@ fn core_clone_larger(b: &mut Bencher) {
             x := x_ + 1;
             ?x_
         }}}}};
-        let i = Iter.range(3);
+        let i = Iter.range(100);
         var sum = 0;
         for (y in i) {
             sum := sum + 1;

--- a/crates/motoko/benches/bench_core.rs
+++ b/crates/motoko/benches/bench_core.rs
@@ -1,27 +1,42 @@
 #![feature(test)]
 
-use motoko::vm_types::Core;
+use motoko::vm_types::{Core, Limits};
 use test::Bencher;
 extern crate test;
 
 #[bench]
-fn core_clone_small(b: &mut Bencher) {
-    let core = Core::from_str("
-        let x = 0;
-        let y = x;
-        y
-    ");
+fn core_clone_smaller(b: &mut Bencher) {
+    let mut core = Core::from_str("let x = 0; x").unwrap();
+    core.continue_(&Limits::default()).unwrap();
 
     b.iter(|| core.clone())
 }
 
 #[bench]
-fn core_clone_large(b: &mut Bencher) {
-    let core = Core::from_str("
-        let x = 0;
-        let y = x;
-        y
-    ");
+fn core_clone_larger(b: &mut Bencher) {
+    let mut core = Core::from_str(
+        r#"
+        let Debug = { print = prim "debugPrint"};
+        var x = 0;
+        let Iter = { range = func(end){
+        { next = func() {
+        if (x == end) {
+            null
+        } else {
+            let x_ = x;
+            x := x_ + 1;
+            ?x_
+        }}}}};
+        let i = Iter.range(3);
+        var sum = 0;
+        for (y in i) {
+            sum := sum + 1;
+            Debug.print sum
+        }
+    "#,
+    )
+    .unwrap();
+    core.continue_(&Limits::default()).unwrap();
 
     b.iter(|| core.clone())
 }

--- a/crates/motoko/benches/bench_eval.rs
+++ b/crates/motoko/benches/bench_eval.rs
@@ -35,7 +35,7 @@ fn eval_larger(b: &mut Bencher) {
                 x := x_ + 1;
                 ?x_
             }}}}};
-            let i = Iter.range(3);
+            let i = Iter.range(100);
             var sum = 0;
             for (y in i) {
                 sum := sum + 1;

--- a/crates/motoko/benches/bench_eval.rs
+++ b/crates/motoko/benches/bench_eval.rs
@@ -1,0 +1,53 @@
+#![feature(test)]
+
+use motoko::{
+    shared::Share,
+    value::Value,
+    vm_types::{Core, Limits},
+};
+use num_bigint::ToBigUint;
+use test::Bencher;
+extern crate test;
+
+#[bench]
+fn eval_smaller(b: &mut Bencher) {
+    let prog = motoko::check::parse("let x = 0; x").unwrap();
+    b.iter(|| {
+        assert_eq!(
+            Core::new(prog.clone()).continue_(&Limits::default()),
+            Ok(Value::Nat(0.to_biguint().unwrap()).share())
+        )
+    })
+}
+
+#[bench]
+fn eval_larger(b: &mut Bencher) {
+    let prog = motoko::check::parse(
+        r#"
+            let Debug = { print = prim "debugPrint"};
+            var x = 0;
+            let Iter = { range = func(end){
+            { next = func() {
+            if (x == end) {
+                null
+            } else {
+                let x_ = x;
+                x := x_ + 1;
+                ?x_
+            }}}}};
+            let i = Iter.range(3);
+            var sum = 0;
+            for (y in i) {
+                sum := sum + 1;
+                Debug.print sum
+            }
+        "#,
+    )
+    .unwrap();
+    b.iter(|| {
+        assert_eq!(
+            Core::new(prog.clone()).continue_(&Limits::default()),
+            Ok(Value::Unit.share())
+        )
+    })
+}

--- a/crates/motoko/benches/bench_vector.rs
+++ b/crates/motoko/benches/bench_vector.rs
@@ -22,11 +22,12 @@ macro_rules! vec_clone_n {
 
             #[bench]
             fn shared_vec_clone(b: &mut Bencher) {
-                let vec: Shared<Vec<Shared<Value>>> = (0..$n)
-                    .into_iter()
-                    .map(|_| SystemTime::now().to_motoko().unwrap().share())
-                    .collect::<Vec<_>>()
-                    .share();
+                let vec: Shared<Vec<Shared<Value>>> = Shared::new(
+                    (0..$n)
+                        .into_iter()
+                        .map(|_| SystemTime::now().to_motoko().unwrap().share())
+                        .collect::<Vec<_>>(),
+                );
 
                 b.iter(|| vec.fast_clone())
             }

--- a/crates/motoko/benches/bench_vector.rs
+++ b/crates/motoko/benches/bench_vector.rs
@@ -7,6 +7,7 @@ macro_rules! vec_clone_n {
             use motoko::shared::{Share, Shared};
             use test::Bencher;
 
+            use motoko::shared::FastClone;
             use motoko::value::{ToMotoko, Value};
             use std::time::SystemTime;
 

--- a/crates/motoko/src/lib/shared.rs
+++ b/crates/motoko/src/lib/shared.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Shared<T> {
+pub struct Shared<T: ?Sized> {
     rc: Rc<T>,
 }
 
@@ -64,14 +64,46 @@ impl<T> AsRef<T> for Shared<T> {
     }
 }
 
-pub trait Share<T> {
+pub trait Share {
     /// TODO: gradually minimize the number of calls to this function.
-    fn share(self) -> Shared<T>;
+    fn share(self) -> Shared<Self>;
 }
 
-impl<T: Clone> Share<T> for T {
-    fn share(self) -> Shared<T> {
+// impl<T: Clone> Share<T> for T {
+//     fn share(self) -> Shared<T> {
+//         Shared::new(self)
+//     }
+// }
+
+impl<T: Clone> Share for crate::ast::NodeData<T> {
+    fn share(self) -> Shared<Self> {
         Shared::new(self)
+    }
+}
+
+impl Share for String {
+    fn share(self) -> Shared<Self> {
+        // Access point for memoization
+        Shared::new(self)
+    }
+}
+
+impl Share for crate::value::Value {
+    fn share(self) -> Shared<Self> {
+        use crate::value::Value;
+        std::thread_local! {
+            static UNIT: Shared<Value> = Shared::new(Value::Unit);
+            static NULL: Shared<Value> = Shared::new(Value::Null);
+            static TRUE: Shared<Value> = Shared::new(Value::Bool(true));
+            static FALSE: Shared<Value> = Shared::new(Value::Bool(false));
+        };
+        match self {
+            Value::Unit => UNIT.with(|s| s.fast_clone()),
+            Value::Null => NULL.with(|s| s.fast_clone()),
+            Value::Bool(true) => TRUE.with(|s| s.fast_clone()),
+            Value::Bool(false) => FALSE.with(|s| s.fast_clone()),
+            _ => Shared::new(self),
+        }
     }
 }
 

--- a/crates/motoko/src/lib/shared.rs
+++ b/crates/motoko/src/lib/shared.rs
@@ -96,6 +96,7 @@ impl Share for crate::value::Value {
             static NULL: Shared<Value> = Shared::new(Value::Null);
             static TRUE: Shared<Value> = Shared::new(Value::Bool(true));
             static FALSE: Shared<Value> = Shared::new(Value::Bool(false));
+            // TODO: common literals such as 0, 1, "", etc?
         };
         match self {
             Value::Unit => UNIT.with(|s| s.fast_clone()),

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::ast::{Dec, Decs, Exp, Function, Id, Literal, Mut};
 use crate::dynamic::Dynamic;
-use crate::shared::Shared;
+use crate::shared::{Shared, FastClone};
 use crate::vm_types::Env;
 
 use im_rc::HashMap;

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     Source, Type, UnOp,
 };
 //use crate::ast_traversal::ToNode;
-use crate::shared::{Share, Shared};
+use crate::shared::{FastClone, Share, Shared};
 use crate::value::{
     Closed, ClosedFunction, CollectionFunction, FastRandIter, FastRandIterFunction,
     HashMapFunction, PrimFunction, Value, ValueError, Value_,
@@ -564,7 +564,6 @@ fn prim_value(name: &str) -> Result<Value, Interruption> {
 fn exp_step(core: &mut Core, exp: Exp_) -> Result<Step, Interruption> {
     use Exp::*;
     let source = exp.1.clone();
-    use crate::shared::fast_option_;
     match &exp.0 {
         Literal(l) => {
             // TODO: partial evaluation would now be highly efficient due to value sharing
@@ -658,7 +657,7 @@ fn exp_step(core: &mut Core, exp: Exp_) -> Result<Step, Interruption> {
         Assign(e1, e2) => exp_conts(core, FrameCont::Assign1(e2.fast_clone()), e1),
         Proj(e1, i) => exp_conts(core, FrameCont::Proj(*i), e1),
         Dot(e1, f) => exp_conts(core, FrameCont::Dot(f.fast_clone()), e1),
-        If(e1, e2, e3) => exp_conts(core, FrameCont::If(e2.fast_clone(), fast_option_(e3)), e1),
+        If(e1, e2, e3) => exp_conts(core, FrameCont::If(e2.fast_clone(), e3.fast_clone()), e1),
         Rel(e1, relop, e2) => {
             exp_conts(core, FrameCont::RelOp1(relop.clone(), e2.fast_clone()), e1)
         }
@@ -1199,7 +1198,7 @@ fn stack_cont(core: &mut Core, v: Value_) -> Result<Step, Interruption> {
                             FieldContext {
                                 mut_: next.0.mut_.clone(),
                                 id: next.0.id.fast_clone(),
-                                typ: crate::shared::fast_option_(&next.0.typ),
+                                typ: next.0.typ.fast_clone(),
                             },
                             rest,
                         ),


### PR DESCRIPTION
Before:
```
test eval_larger  ... bench:     737,916 ns/iter (+/- 21,795)
test eval_smaller ... bench:       2,225 ns/iter (+/- 21)
```

After:
```
test eval_larger  ... bench:     701,332 ns/iter (+/- 37,938)
test eval_smaller ... bench:       2,205 ns/iter (+/- 119)
```

(Essentially the same performance, but this change seems reasonable for reclaiming some extra memory). 