### PR TITLE
Dynamic value UX improvements

### DIFF
--- a/crates/motoko/src/lib/dynamic.rs
+++ b/crates/motoko/src/lib/dynamic.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::ast::{Inst, ToId};
 //use crate::shared::Shared;
 use crate::value::{DynamicValue, Value, Value_};
-use crate::vm_types::Interruption;
+use crate::vm_types::{Core, Interruption};
 
 pub use dyn_clone::DynClone;
 
@@ -19,15 +19,15 @@ pub trait Dynamic: Debug + DynClone + DynHash {
         Value::Dynamic(DynamicValue(Rc::new(RefCell::new(self))))
     }
 
-    fn get_index(&self, _index: Value_) -> Result {
+    fn get_index(&self, _core: &Core, _index: Value_) -> Result {
         Err(Interruption::IndexOutOfBounds)
     }
 
-    fn set_index(&mut self, _index: Value_, _value: Value_) -> Result<()> {
+    fn set_index(&mut self, _core: &mut Core, _index: Value_, _value: Value_) -> Result<()> {
         Err(Interruption::IndexOutOfBounds)
     }
 
-    fn get_field(&self, name: &str) -> Result {
+    fn get_field(&self, _core: &Core, name: &str) -> Result {
         Err(Interruption::UnboundIdentifer(name.to_id()))
     }
 
@@ -35,7 +35,7 @@ pub trait Dynamic: Debug + DynClone + DynHash {
     //     Err(Interruption::UnboundIdentifer(name.to_string()))
     // }
 
-    fn call(&mut self, _inst: &Option<Inst>, _args: Value_) -> Result {
+    fn call(&mut self, _core: &mut Core, _inst: &Option<Inst>, _args: Value_) -> Result {
         Err(Interruption::TypeMismatch)
     }
 

--- a/crates/motoko/src/lib/mod.rs
+++ b/crates/motoko/src/lib/mod.rs
@@ -36,4 +36,4 @@ pub use crate::shared::{Share, Shared};
 pub use crate::value::ToMotoko;
 pub use crate::value::{Value, ValueError, Value_};
 pub use crate::vm::{eval, eval_into, eval_limit};
-pub use crate::vm_types::Core;
+pub use crate::vm_types::{Core, Interruption};

--- a/crates/motoko/src/lib/mod.rs
+++ b/crates/motoko/src/lib/mod.rs
@@ -27,3 +27,13 @@ pub mod shared;
 pub mod value;
 pub mod vm;
 pub mod vm_types;
+
+#[cfg(feature = "parser")]
+pub use crate::check::parse;
+pub use crate::dynamic::Dynamic;
+pub use crate::shared::{Share, Shared};
+#[cfg(feature = "to-motoko")]
+pub use crate::value::ToMotoko;
+pub use crate::value::{Value, ValueError, Value_};
+pub use crate::vm::{eval, eval_into, eval_limit};
+pub use crate::vm_types::Core;

--- a/crates/motoko/src/lib/shared.rs
+++ b/crates/motoko/src/lib/shared.rs
@@ -89,6 +89,12 @@ pub trait Share {
 //     }
 // }
 
+impl<T: Share> From<T> for Shared<T> {
+    fn from(value: T) -> Self {
+        value.share()
+    }
+}
+
 impl<T: Clone> Share for crate::ast::NodeData<T> {
     fn share(self) -> Shared<Self> {
         Shared::new(self)

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -642,3 +642,4 @@ impl serde::de::Error for ValueError {
         ValueError::ToRust(msg.to_string())
     }
 }
+

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -139,6 +139,12 @@ impl DynamicValue {
     }
 }
 
+impl<'a> FastClone<DynamicValue> for &'a DynamicValue {
+    fn fast_clone(self) -> DynamicValue {
+        self.clone()
+    }
+}
+
 impl std::fmt::Debug for DynamicValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.0)

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -374,7 +374,7 @@ fn call_cont(
             let func_value = core.deref_value(func_value)?; // Account for dynamic value pointers
             match &*func_value {
                 Value::Dynamic(d) => {
-                    let result = d.dynamic_mut().call(&inst, args_value.fast_clone())?;
+                    let result = d.dynamic_mut().call(core, &inst, args_value.fast_clone())?;
                     core.cont = Cont::Value_(result);
                     Ok(Step {})
                 }
@@ -855,7 +855,10 @@ fn source_from_cont(cont: &Cont) -> Source {
 mod store {
     use num_traits::ToPrimitive;
 
-    use crate::{shared::Share, value::Value_};
+    use crate::{
+        shared::{FastClone, Share},
+        value::Value_,
+    };
 
     use super::{Core, Interruption, Mut, Pointer, Value};
 
@@ -896,7 +899,7 @@ mod store {
                 }
             }
             Value::Dynamic(d) => {
-                d.dynamic_mut().set_index(i, v)?;
+                d.fast_clone().dynamic_mut().set_index(core, i, v)?;
                 Ok(())
             }
             _ => Err(Interruption::TypeMismatch),
@@ -1050,7 +1053,7 @@ fn stack_cont(core: &mut Core, v: Value_) -> Result<Step, Interruption> {
                             Ok(Step {})
                         }
                         (Value::Dynamic(d), _) => {
-                            core.cont = cont_value((*d.dynamic().get_index(v)?).clone());
+                            core.cont = cont_value((*d.dynamic().get_index(core, v)?).clone());
                             Ok(Step {})
                         }
                         _ => Err(Interruption::TypeMismatch),
@@ -1205,7 +1208,7 @@ fn stack_cont(core: &mut Core, v: Value_) -> Result<Step, Interruption> {
                     }
                 }
                 Value::Dynamic(d) => {
-                    let f = d.dynamic().get_field(f.0.as_str())?;
+                    let f = d.dynamic().get_field(core, f.0.as_str())?;
                     core.cont = Cont::Value_(f);
                     Ok(Step {})
                 }

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -1653,6 +1653,16 @@ impl Core {
             _ => Ok(value),
         }
     }
+
+    pub fn assign(&mut self, id: impl ToId, value: Value_) {
+        self.env.insert(id.to_id(), value);
+    }
+
+    pub fn assign_alloc(&mut self, id: impl ToId, value: Value_) -> Pointer {
+        let pointer = self.alloc(value);
+        self.assign(id, Value::Pointer(pointer.fast_clone()).share());
+        pointer
+    }
 }
 
 // For core Motoko state initializing local VM state.

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -1629,6 +1629,7 @@ impl Core {
         self.continue_(limits)
     }
 
+    #[inline]
     pub fn alloc(&mut self, value: impl Into<Value_>) -> Pointer {
         let value = value.into();
         let ptr = Pointer(self.next_pointer);
@@ -1637,10 +1638,12 @@ impl Core {
         ptr
     }
 
+    #[inline]
     pub fn dealloc(&mut self, pointer: &Pointer) -> Option<Value_> {
         self.store.remove(pointer)
     }
 
+    #[inline]
     pub fn deref(&mut self, pointer: &Pointer) -> Result<Value_, Interruption> {
         self.store
             .get(pointer)
@@ -1648,6 +1651,7 @@ impl Core {
             .map(|v| v.fast_clone())
     }
 
+    #[inline]
     pub fn deref_value(&mut self, value: impl Into<Value_>) -> Result<Value_, Interruption> {
         let value = value.into();
         match &*value {
@@ -1656,11 +1660,13 @@ impl Core {
         }
     }
 
+    #[inline]
     pub fn assign(&mut self, id: impl ToId, value: impl Into<Value_>) {
         let value = value.into();
         self.env.insert(id.to_id(), value);
     }
 
+    #[inline]
     pub fn assign_alloc(&mut self, id: impl ToId, value: impl Into<Value_>) -> Pointer {
         let pointer = self.alloc(value);
         self.assign(id, Value::Pointer(pointer.fast_clone()).share());

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -301,6 +301,7 @@ pub enum Interruption {
     #[cfg(feature = "parser")]
     SyntaxError(SyntaxError),
     ValueError(ValueError),
+    EvalInitError(EvalInitError),
     UnboundIdentifer(Identifier),
     UnrecognizedPrim(String),
     BlockedAwaiting,
@@ -314,8 +315,25 @@ pub enum Interruption {
     NotYetImplemented(NYI),
     Unknown,
     Impossible,
-    EvalInitError(EvalInitError),
     Other(String),
+}
+
+impl From<SyntaxError> for Interruption {
+    fn from(err: SyntaxError) -> Self {
+        Interruption::SyntaxError(err)
+    }
+}
+
+impl From<ValueError> for Interruption {
+    fn from(err: ValueError) -> Self {
+        Interruption::ValueError(err)
+    }
+}
+
+impl From<EvalInitError> for Interruption {
+    fn from(err: EvalInitError) -> Self {
+        Interruption::EvalInitError(err)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -58,6 +58,12 @@ pub struct Id(u64);
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Pointer(pub usize);
 
+impl<'a> crate::shared::FastClone<Pointer> for &'a Pointer {
+    fn fast_clone(self) -> Pointer {
+        self.clone()
+    }
+}
+
 /// Local continuation as a Dec sequence.  This Vector permits
 /// sharing.
 ///

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -61,11 +61,9 @@ fn dyn_struct() {
         }
     }
 
-    let value = Struct::default().into_value().share();
-
     let mut core = motoko::vm_types::Core::empty();
 
-    core.assign_alloc("value".to_id(), value);
+    core.assign_alloc("value".to_id(), Struct::default().into_value());
 
     assert_eq!(
         core.eval_prog(motoko::check::parse("value[5] := 'a'; value[5]").unwrap())

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -64,10 +64,8 @@ fn dyn_struct() {
     let value = Struct::default().into_value().share();
 
     let mut core = motoko::vm_types::Core::empty();
-    let pointer = core.alloc(value);
 
-    core.env
-        .insert("value".to_id(), Value::Pointer(pointer).share());
+    core.assign_alloc("value".to_id(), value);
 
     assert_eq!(
         core.eval_prog(motoko::check::parse("value[5] := 'a'; value[5]").unwrap())

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -1,7 +1,7 @@
 use motoko::ast::ToId;
-use motoko::shared::{Share, FastClone};
+use motoko::shared::{FastClone, Share};
 use motoko::value::Value;
-use motoko::vm_types::Interruption;
+use motoko::vm_types::{Core, Interruption};
 use motoko::{dynamic::Dynamic, value::Value_};
 
 #[test]
@@ -13,14 +13,19 @@ fn dyn_struct() {
     }
 
     impl Dynamic for Struct {
-        fn get_index(&self, index: Value_) -> motoko::dynamic::Result {
+        fn get_index(&self, _core: &Core, index: Value_) -> motoko::dynamic::Result {
             self.map
                 .get(&index)
                 .map(FastClone::fast_clone)
                 .ok_or(Interruption::IndexOutOfBounds)
         }
 
-        fn set_index(&mut self, key: Value_, value: Value_) -> motoko::dynamic::Result<()> {
+        fn set_index(
+            &mut self,
+            _core: &mut Core,
+            key: Value_,
+            value: Value_,
+        ) -> motoko::dynamic::Result<()> {
             self.map.insert(key, value);
             Ok(())
         }
@@ -44,6 +49,7 @@ fn dyn_struct() {
 
         fn call(
             &mut self,
+            _core: &mut Core,
             _inst: &Option<motoko::ast::Inst>,
             args: Value_,
         ) -> motoko::dynamic::Result {


### PR DESCRIPTION
- Passes a `Core` reference to all `Dynamic` trait methods
- Includes `Core.assign()` and `Core.assign_alloc()` to conveniently add values to the environment
- Makes it possible to omit `_.share()` when passing a value to any `Core` helper function 
- Re-exports common types at the top-level module
- Automatically converts from `ValueError` to `Interruption` (etc.) when using the `?` operator
