### PR TITLE
Optimize VM: Opaque pointers (vs existing var-pointer).

### DIFF
--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -118,7 +118,10 @@ pub enum Value {
     Object(HashMap<Id, FieldValue>),
     Option(Value_),
     Variant(Id, Option<Value_>),
+    /// `var` pointers are implicitly dereferenced (as R-values, but not as L-values).
     Pointer(Pointer),
+    /// an opaque pointer is not implicitly dereferenced during evaluation (unlike `var` `Pointer`s).
+    Opaque(Pointer),
     Index(Pointer, Value_),
     Function(ClosedFunction),
     PrimFunction(PrimFunction),
@@ -458,6 +461,7 @@ impl Value {
                 Object(map)
             }
             Value::Pointer(_) => Err(ValueError::ToRust("Pointer".to_string()))?,
+            Value::Opaque(_) => Err(ValueError::ToRust("Opaque".to_string()))?,
             Value::Index(_, _) => Err(ValueError::ToRust("Index".to_string()))?,
             Value::Function(_) => Err(ValueError::ToRust("Function".to_string()))?,
             Value::PrimFunction(_) => Err(ValueError::ToRust("PrimFunction".to_string()))?,

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -1,5 +1,5 @@
 use motoko::ast::ToId;
-use motoko::shared::{Share, FastClone};
+use motoko::shared::{FastClone, Share};
 use motoko::value::Value;
 use motoko::vm_types::Interruption;
 use motoko::{dynamic::Dynamic, value::Value_};

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -343,7 +343,7 @@ fn prim_collection_hashmap() {
 #[test]
 fn fastranditer() {
     assert_(
-        "var i = prim \"fastRandIterNew\" (null, 33); let (x, i) = (prim \"fastRandIterNext\" i); (x, (prim \"fastRandIterNext\" i).0)",
+        "var i = prim \"fastRandIterNew\" (null, 33); let x = (prim \"fastRandIterNext\" i); (x, (prim \"fastRandIterNext\" i))",
         "(?1592943, ?1731023874)",
     );
 }

--- a/crates/motoko_proc_macro/tests/test_eval_open_block.rs
+++ b/crates/motoko_proc_macro/tests/test_eval_open_block.rs
@@ -42,63 +42,12 @@ fn test_hashmap_performance_steps() {
         parse_static!(
             "
       var i = prim \"fastRandIterNew\" (?size, 1);
-      var j = {
-        next = func () {
-          let (n, i_) = prim \"fastRandIterNext\" i;
-          i := i_;
-          n
-        }
-      };
+      let j = {
+        next = func () { prim \"fastRandIterNext\" i }
+        };
       for (x in j) {
         let s = prim \"natToText\" x;
         let (m, _) = prim \"hashMapPut\" (map, x, s);
-        map := m;
-      }
-    "
-        )
-        .clone(),
-    )
-    .unwrap();
-
-    // batch get.
-    let size = 10;
-    core.eval_open_block(
-        vec![("size", Value::Nat(BigUint::from(size as u32)).share())],
-        parse_static!(
-            "
-      var i = prim \"fastRandIterNew\" (?size, 1);
-      var j = {
-        next = func () {
-          let (n, i_) = prim \"fastRandIterNext\" i;
-          i := i_;
-          n
-        }
-      };
-      for (x in j) {
-        let _ = prim \"hashMapGet\" (map, x);
-      }
-    "
-        )
-        .clone(),
-    )
-    .unwrap();
-
-    // batch remove.
-    let size = 10;
-    core.eval_open_block(
-        vec![("size", Value::Nat(BigUint::from(size as u32)).share())],
-        parse_static!(
-            "
-      var i = prim \"fastRandIterNew\" (?size, 1);
-      var j = {
-        next = func () {
-          let (n, i_) = prim \"fastRandIterNext\" i;
-          i := i_;
-          n
-        }
-      };
-      for (x in j) {
-        let (m, _) = prim \"hashMapRemove\" (map, x);
         map := m;
       }
     "

--- a/crates/motoko_proc_macro/tests/test_hashmap_randiter_integration.rs
+++ b/crates/motoko_proc_macro/tests/test_hashmap_randiter_integration.rs
@@ -21,9 +21,7 @@ fn test_hashmap_randiter_intergration() {
                    null
                  } else {
                    c := c + 1;
-                   let (n, i) = prim \"fastRandIterNext\" rand_;
-                   rand_ := i;
-                   n
+                   prim \"fastRandIterNext\" rand_;
                  }
                 }
               }


### PR DESCRIPTION
Consider this program
```
let rands = func(count){
  var c = 0;
  { next = func() {
     if (c == count) {
       null
     } else {
       c := c + 1;
       let (n, i) = prim "fastRandIterNext" rand_;
       rand_ := i;
       n
     }
    }
  }
};
let j = rands(5);
for (x in j) {
  // Do something iterative with x.
}
```

(also same as here https://github.com/dfinity/canister-profiling/pull/16/files#diff-ffc8c4b16dc3edfe909f12892610b23d05804b5fe2195d9f544b1933e347d3e0R13 )

When I run this program (no body in the for loop), I get 54 reductions, and 310 total steps before termination.

Most of the steps are evaluating the next function in the VM’s eval logic — What if I were to internalize all of these steps into the Rust side?  This PR explores such an idea.