### PR TITLE
VM Opt: for loop fast path for opaque iterators.

### DIFF
--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -646,4 +646,3 @@ impl serde::de::Error for ValueError {
         ValueError::ToRust(msg.to_string())
     }
 }
-

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -1034,6 +1034,7 @@ fn stack_cont(core: &mut Core, v: Value_) -> Result<Step, Interruption> {
         };
         match opaque_iter_next(core, &ptr)? {
             None => {
+                core.stack.pop_front();
                 core.cont = cont_value(Value::Unit);
                 Ok(Step {})
             }

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -83,7 +83,7 @@ pub enum Cont {
 }
 
 pub mod stack {
-    use super::{Cont, Env, Vector};
+    use super::{Cont, Env, Pointer, Vector};
     use crate::ast::{
         BinOp, Cases, Dec_, ExpField_, Exp_, Id_, Inst, Mut, Pat_, PrimType, RelOp, Source, Type_,
         UnOp,
@@ -130,6 +130,8 @@ pub mod stack {
         For2(Pat_, Value_, Exp_),
         // For3 is waiting for for-loop body to evaluate.
         For3(Pat_, Value_, Exp_),
+        // For-loop iterator is an opaque object in store.
+        ForOpaqueIter(Pat_, Pointer, Exp_),
         And1(Exp_),
         And2,
         Or1(Exp_),

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -349,6 +349,14 @@ fn fastranditer() {
 }
 
 #[test]
+fn fastranditer_fastfor() {
+    assert_(
+        "for (x in prim \"fastRandIterNew\" (?3, 3)) { }",
+        "()",
+    );
+}
+
+#[test]
 fn function_call_return_restores_env() {
     assert_("func f() { }; let x = 0; x", "0");
     assert_("func f() { }; let x = 0; f(); x", "0");


### PR DESCRIPTION
A `for` loop whose iterator is an opaque object (see #120) can avoid the two-phase stepping logic of a general `for` loop, and even avoid popping the `for` loop's (new, special) stack frame.