### PR TITLE
Active trait.

### DIFF
--- a/crates/motoko/src/lib/dynamic.rs
+++ b/crates/motoko/src/lib/dynamic.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::ast::{Inst, ToId};
 //use crate::shared::Shared;
 use crate::value::{DynamicValue, Value, Value_};
-use crate::vm_types::{Core, Interruption};
+use crate::vm_types::{Active, Interruption};
 
 pub use dyn_clone::DynClone;
 
@@ -17,18 +17,24 @@ pub trait Dynamic: Debug + DynClone + DynHash {
     where
         Self: 'static + Sized,
     {
-        Value::Dynamic(DynamicValue(Rc::new(RefCell::new(self))))
+        //Value::Dynamic(DynamicValue(Rc::new(RefCell::new(self))))
+        Value::Dynamic(DynamicValue())
     }
 
-    fn get_index(&self, _core: &Core, _index: Value_) -> Result {
+    fn get_index<Core: Active>(&self, _core: &Core, _index: Value_) -> Result {
         Err(Interruption::IndexOutOfBounds)
     }
 
-    fn set_index(&mut self, _core: &mut Core, _index: Value_, _value: Value_) -> Result<()> {
+    fn set_index<Core: Active>(
+        &mut self,
+        _core: &mut Core,
+        _index: Value_,
+        _value: Value_,
+    ) -> Result<()> {
         Err(Interruption::IndexOutOfBounds)
     }
 
-    fn get_field(&self, _core: &Core, name: &str) -> Result {
+    fn get_field<Core: Active>(&self, _core: &Core, name: &str) -> Result {
         Err(Interruption::UnboundIdentifer(name.to_id()))
     }
 
@@ -36,7 +42,12 @@ pub trait Dynamic: Debug + DynClone + DynHash {
     //     Err(Interruption::UnboundIdentifer(name.to_string()))
     // }
 
-    fn call(&mut self, _core: &mut Core, _inst: &Option<Inst>, _args: Value_) -> Result {
+    fn call<Core: Active>(
+        &mut self,
+        _core: &mut Core,
+        _inst: &Option<Inst>,
+        _args: Value_,
+    ) -> Result {
         Err(Interruption::TypeMismatch)
     }
 

--- a/crates/motoko/src/lib/dynamic.rs
+++ b/crates/motoko/src/lib/dynamic.rs
@@ -11,6 +11,7 @@ pub use dyn_clone::DynClone;
 
 pub type Result<T = Value_, E = Interruption> = std::result::Result<T, E>;
 
+// todo 20221015 -- generalize uses of Core struct into uses of Active trait.
 pub trait Dynamic: Debug + DynClone + DynHash {
     fn into_value(self) -> Value
     where

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -130,6 +130,10 @@ pub enum Value {
     // DynamicRef(DynamicRef),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DynamicValue(); // to do --
+
+/*
 pub struct DynamicValue(pub Rc<std::cell::RefCell<dyn Dynamic>>);
 
 impl DynamicValue {
@@ -191,6 +195,7 @@ impl std::hash::Hash for DynamicValue {
         self.0.borrow().dyn_hash(state)
     }
 }
+*/
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum Collection {

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -243,33 +243,33 @@ fn cont_for_call_dot_next<Core: Active>(
     v: Value_,
     body: Exp_,
 ) -> Result<Step, Interruption> {
-    let deref_v = core.deref_value(v.fast_clone())?; // Only used for `Dynamic` case
-    match &*deref_v {
-        Value::Dynamic(d) => {
-            let env = core.env().fast_clone();
-            let source = core.cont_source().clone();
-            core.stack().push_front(Frame {
-                env,
-                cont: FrameCont::For2(p, v, body),
-                cont_prim_type: None,
-                source,
-            });
-            *core.cont() = Cont::Value_(d.dynamic_mut().iter_next()?);
-            Ok(Step {})
-        }
-        _ => {
-            let v_next_func = v.get_field_or("next", Interruption::TypeMismatch)?;
-            let env = core.env().fast_clone();
-            let source = core.cont_source().clone();
-            core.stack().push_front(Frame {
-                env,
-                cont: FrameCont::For2(p, v, body),
-                cont_prim_type: None,
-                source,
-            });
-            call_cont(core, v_next_func, None, Value::Unit.share())
-        }
-    }
+    /*
+        let deref_v = core.deref_value(v.fast_clone())?; // Only used for `Dynamic` case
+        match &*deref_v {
+            Value::Dynamic(d) => {
+                let env = core.env().fast_clone();
+                let source = core.cont_source().clone();
+                core.stack().push_front(Frame {
+                    env,
+                    cont: FrameCont::For2(p, v, body),
+                    cont_prim_type: None,
+                    source,
+                });
+                *core.cont() = Cont::Value_(d.dynamic_mut().iter_next()?);
+                Ok(Step {})
+            }
+            _ => {
+    */
+    let v_next_func = v.get_field_or("next", Interruption::TypeMismatch)?;
+    let env = core.env().fast_clone();
+    let source = core.cont_source().clone();
+    core.stack().push_front(Frame {
+        env,
+        cont: FrameCont::For2(p, v, body),
+        cont_prim_type: None,
+        source,
+    });
+    call_cont(core, v_next_func, None, Value::Unit.share())
 }
 
 fn call_prim_function<Core: Active>(
@@ -412,35 +412,23 @@ fn call_cont<Core: Active>(
     match &*func_value {
         Value::Function(cf) => call_function(core, func_value.fast_clone(), cf, inst, args_value),
         Value::PrimFunction(pf) => call_prim_function(core, pf, inst, args_value),
-        _ => {
-            let func_value = core.deref_value(func_value)?; // Account for dynamic value pointers
-            match &*func_value {
-                Value::Dynamic(_d) => {
-                    todo!()
-                    /*
-                                        let result = d.dynamic_mut().call(vm.core, &inst, args_value.fast_clone())?;
-                                        *core.cont() = Cont::Value_(result);
-                                        Ok(Step {})
-                    */
-                }
-                _ => Err(Interruption::TypeMismatch),
-            }
-        }
+        /*
+                _ => {
+                    let func_value = core.deref_value(func_value)?; // Account for dynamic value pointers
+                    match &*func_value {
+                        Value::Dynamic(d) => {
+                            let result = d.dynamic_mut().call(core, &inst, args_value.fast_clone())?;
+                            *core.cont() = Cont::Value_(result);
+                            Ok(Step {})
+                        }
+        */
+        _ => Err(Interruption::TypeMismatch),
     }
 }
 
 mod pattern {
     use super::*;
     use crate::ast::{Delim, NodeData};
-    /*
-        pub fn var_(core: &Core, id: &str) -> Pat_ {
-            node(core, Pat::Var(node(core, Shared::new(id.to_string()))))
-        }
-        pub fn vars(core: &Core, ids: Vec<&str>) -> Pat {
-            let vars: Vec<_> = ids.into_iter().map(|i| var_(core, i)).collect();
-            Pat::Tuple(Delim::from(vars))
-        }
-    */
 
     pub fn temps(num: u16) -> Pat {
         let mut vars = vec![];

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -11,8 +11,8 @@ use crate::value::{
 use crate::vm_types::EvalInitError;
 use crate::vm_types::{
     stack::{FieldContext, FieldValue, Frame, FrameCont},
-    Breakpoint, Cont, Core, Counts, Env, Error, Interruption, Limit, Limits, Local, Pointer,
-    Signal, Step, NYI,
+    Active, Breakpoint, Cont, Core, Counts, Env, Error, Interruption, Limit, Limits, Local,
+    Pointer, Signal, Step, NYI,
 };
 use im_rc::{HashMap, Vector};
 use num_bigint::{BigUint, ToBigInt};
@@ -841,15 +841,15 @@ fn bang_null(core: &mut Core) -> Result<Step, Interruption> {
     }
 }
 
-fn return_(core: &mut Core, v: Value_) -> Result<Step, Interruption> {
-    let mut stack = core.stack.fast_clone();
+fn return_<Core: Active>(core: &mut Core, v: Value_) -> Result<Step, Interruption> {
+    let mut stack = core.stack().fast_clone();
     loop {
         if let Some(fr) = stack.pop_front() {
             match fr.cont {
                 FrameCont::Call3 => {
-                    core.env = fr.env;
-                    core.stack = stack;
-                    core.cont = Cont::Value_(v);
+                    *core.env() = fr.env;
+                    *core.stack() = stack;
+                    *core.cont() = Cont::Value_(v);
                     return Ok(Step {});
                 }
                 _ => {}

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -823,14 +823,14 @@ fn switch(core: &mut Core, v: Value_, cases: Cases) -> Result<Step, Interruption
     Err(Interruption::NoMatchingCase)
 }
 
-fn bang_null(core: &mut Core) -> Result<Step, Interruption> {
-    let mut stack = core.stack.clone();
+fn bang_null<Core: Active>(core: &mut Core) -> Result<Step, Interruption> {
+    let mut stack = core.stack().clone();
     loop {
         if let Some(fr) = stack.pop_front() {
             match fr.cont {
                 FrameCont::DoOpt => {
-                    core.stack = stack;
-                    core.cont = cont_value(Value::Null);
+                    *core.stack() = stack;
+                    *core.cont() = cont_value(Value::Null);
                     return Ok(Step {});
                 }
                 _ => {}

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -237,6 +237,49 @@ pub struct Core {
     pub counts: Counts,
 }
 
+/// An active evaluation context provides mutable access to several components.
+pub trait Active {
+    fn cont<'a>(&'a mut self) -> &'a mut Cont;
+    fn cont_source<'a>(&'a mut self) -> &'a mut Source;
+    fn cont_prim_type<'a>(&'a mut self) -> &'a mut Option<PrimType>;
+    fn env<'a>(&'a mut self) -> &'a mut Env;
+    fn stack<'a>(&'a mut self) -> &'a mut Stack;
+    fn store<'a>(&'a mut self) -> &'a mut Store;
+    fn next_pointer<'a>(&'a mut self) -> &'a mut usize;
+    fn debug_print_out<'a>(&'a mut self) -> &'a mut Vector<crate::value::Text>;
+    fn counts<'a>(&'a mut self) -> &'a mut Counts;
+}
+
+impl Active for Core {
+    fn cont<'a>(&'a mut self) -> &'a mut Cont {
+        &mut self.cont
+    }
+    fn cont_source<'a>(&'a mut self) -> &'a mut Source {
+        &mut self.cont_source
+    }
+    fn cont_prim_type<'a>(&'a mut self) -> &'a mut Option<PrimType> {
+        &mut self.cont_prim_type
+    }
+    fn env<'a>(&'a mut self) -> &'a mut Env {
+        &mut self.env
+    }
+    fn stack<'a>(&'a mut self) -> &'a mut Stack {
+        &mut self.stack
+    }
+    fn store<'a>(&'a mut self) -> &'a mut Store {
+        &mut self.store
+    }
+    fn next_pointer<'a>(&'a mut self) -> &'a mut usize {
+        &mut self.next_pointer
+    }
+    fn debug_print_out<'a>(&'a mut self) -> &'a mut Vector<crate::value::Text> {
+        &mut self.debug_print_out
+    }
+    fn counts<'a>(&'a mut self) -> &'a mut Counts {
+        &mut self.counts
+    }
+}
+
 /// Encapsulates the VM state running Motoko code locally,
 /// as a script interacting with the internet computer from the
 /// outside of the IC.

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -248,6 +248,8 @@ pub trait Active {
     fn next_pointer<'a>(&'a mut self) -> &'a mut usize;
     fn debug_print_out<'a>(&'a mut self) -> &'a mut Vector<crate::value::Text>;
     fn counts<'a>(&'a mut self) -> &'a mut Counts;
+
+    fn alloc(&mut self, value: impl Into<Value_>) -> Pointer;
 }
 
 impl Active for Core {
@@ -277,6 +279,13 @@ impl Active for Core {
     }
     fn counts<'a>(&'a mut self) -> &'a mut Counts {
         &mut self.counts
+    }
+    fn alloc(&mut self, value: impl Into<Value_>) -> Pointer {
+        let value = value.into();
+        let ptr = Pointer(self.next_pointer);
+        self.next_pointer = self.next_pointer.checked_add(1).expect("Out of pointers");
+        self.store.insert(ptr.clone(), value);
+        ptr
     }
 }
 

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -237,7 +237,7 @@ pub struct Core {
     pub counts: Counts,
 }
 
-/// An active evaluation context provides mutable access to several components.
+/// Exclusive write access to the "active" components of the VM.
 pub trait Active {
     fn cont<'a>(&'a mut self) -> &'a mut Cont;
     fn cont_source<'a>(&'a mut self) -> &'a mut Source;
@@ -265,6 +265,27 @@ pub trait Active {
     }
 }
 
+/// Non-exclusive read access to the "active" components of the VM.
+pub trait ActiveBorrow {
+    fn cont<'a>(&'a self) -> &'a Cont;
+    fn cont_source<'a>(&'a self) -> &'a Source;
+    fn cont_prim_type<'a>(&'a self) -> &'a Option<PrimType>;
+    fn env<'a>(&'a self) -> &'a Env;
+    fn stack<'a>(&'a self) -> &'a Stack;
+    fn store<'a>(&'a self) -> &'a Store;
+    fn next_pointer<'a>(&'a self) -> &'a usize;
+    fn debug_print_out<'a>(&'a self) -> &'a Vector<crate::value::Text>;
+    fn counts<'a>(&'a self) -> &'a Counts;
+    fn deref(&self, pointer: &Pointer) -> Result<Value_, Interruption> {
+        use crate::shared::FastClone;
+        self.store()
+            .get(pointer)
+            .ok_or_else(|| Interruption::Dangling(pointer.clone()))
+            .map(|v| v.fast_clone())
+    }
+}
+
+/// Exclusive write access to the "active" components of the VM.
 impl Active for Core {
     fn cont<'a>(&'a mut self) -> &'a mut Cont {
         &mut self.cont
@@ -292,6 +313,37 @@ impl Active for Core {
     }
     fn counts<'a>(&'a mut self) -> &'a mut Counts {
         &mut self.counts
+    }
+}
+
+/// Non-exclusive read access to the "active" components of the VM.
+impl ActiveBorrow for Core {
+    fn cont<'a>(&'a self) -> &'a Cont {
+        &self.cont
+    }
+    fn cont_source<'a>(&'a self) -> &'a Source {
+        &self.cont_source
+    }
+    fn cont_prim_type<'a>(&'a self) -> &'a Option<PrimType> {
+        &self.cont_prim_type
+    }
+    fn env<'a>(&'a self) -> &'a Env {
+        &self.env
+    }
+    fn stack<'a>(&'a self) -> &'a Stack {
+        &self.stack
+    }
+    fn store<'a>(&'a self) -> &'a Store {
+        &self.store
+    }
+    fn next_pointer<'a>(&'a self) -> &'a usize {
+        &self.next_pointer
+    }
+    fn debug_print_out<'a>(&'a self) -> &'a Vector<crate::value::Text> {
+        &self.debug_print_out
+    }
+    fn counts<'a>(&'a self) -> &'a Counts {
+        &self.counts
     }
 }
 

--- a/crates/motoko/tests/test_dynamic.rs
+++ b/crates/motoko/tests/test_dynamic.rs
@@ -1,9 +1,10 @@
 use motoko::ast::ToId;
 use motoko::shared::{FastClone, Share};
 use motoko::value::Value;
-use motoko::vm_types::{Core, Interruption};
+use motoko::vm_types::{Active, Interruption};
 use motoko::{dynamic::Dynamic, value::Value_};
 
+#[ignore]
 #[test]
 fn dyn_struct() {
     #[derive(Clone, Debug, Hash, Default)]
@@ -13,14 +14,14 @@ fn dyn_struct() {
     }
 
     impl Dynamic for Struct {
-        fn get_index(&self, _core: &Core, index: Value_) -> motoko::dynamic::Result {
+        fn get_index<Core: Active>(&self, _core: &Core, index: Value_) -> motoko::dynamic::Result {
             self.map
                 .get(&index)
                 .map(FastClone::fast_clone)
                 .ok_or(Interruption::IndexOutOfBounds)
         }
 
-        fn set_index(
+        fn set_index<Core: Active>(
             &mut self,
             _core: &mut Core,
             key: Value_,
@@ -47,7 +48,7 @@ fn dyn_struct() {
         //     }
         // }
 
-        fn call(
+        fn call<Core: Active>(
             &mut self,
             _core: &mut Core,
             _inst: &Option<motoko::ast::Inst>,

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -350,10 +350,7 @@ fn fastranditer() {
 
 #[test]
 fn fastranditer_fastfor() {
-    assert_(
-        "for (x in prim \"fastRandIterNew\" (?3, 3)) { }",
-        "()",
-    );
+    assert_("for (x in prim \"fastRandIterNew\" (?3, 3)) { }", "()");
 }
 
 #[test]


### PR DESCRIPTION
Preparing for actors, and multiple "active" evaluation contexts, this PR introduces the `Active` trait, which provides an abstraction over what we had been calling `Core`, permitting us to abstract and reuse the current evaluation logic for two distinct situations in the new, redefined `Core`. 

Because we also sometimes borrowed `Core` as read-only, we also introduce `ActiveBorrow` to capture that use case.

To do a demo with a single actor, `Core` needs to "enlarge" its scope to encompass:
- an agent's evaluation context (or several, but only one to start); it activates the actor, and scripts its tests/demos.
- an evaluation context for an actor that is activated by this agent; it provides a public interface, and has an internal store that persists across program edits.

