### PR TITLE
Improve block comment tokenization

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.18"
+version = "0.0.19"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/src/lib/check.rs
+++ b/crates/motoko/src/lib/check.rs
@@ -6,18 +6,6 @@ use crate::parser_types::SyntaxError;
 use regex::Regex;
 use structopt::lazy_static::lazy_static;
 
-// TODO: refactor lalrpop lexer details
-// impl crate::parser::__ToTriple for Loc<Token> {
-//     fn to_triple(
-//         Loc(token, src): Self,
-//     ) -> Result<
-//         (crate::ast::Source, Token, crate::ast::Source),
-//         lalrpop_util::ParseError<crate::ast::Source, Token, &'static str>,
-//     > {
-//         Ok((src.clone(), token, src))
-//     }
-// }
-
 // Replace a token tree with equivalent whitespace
 fn spacify_token_tree(tt: TokenTree) -> TokenTree {
     lazy_static! {
@@ -36,11 +24,11 @@ fn spacify_token_tree(tt: TokenTree) -> TokenTree {
 fn prepare_token_tree(tt: TokenTree) -> TokenTree {
     match tt {
         TokenTree::Token(Loc(ref token, _)) => match token {
-            Token::LineComment(_) => spacify_token_tree(tt),
+            Token::LineComment(_) | Token::BlockComment(_) => spacify_token_tree(tt),
             // Token::Space(_) | Token::MultiLineSpace(_) => None,
             _ => tt,
         },
-        TokenTree::Group(_, GroupType::BlockComment, _) => spacify_token_tree(tt),
+        TokenTree::Group(_, GroupType::Comment, _) => spacify_token_tree(tt),
         TokenTree::Group(trees, group, pair) => TokenTree::Group(
             trees.into_iter().map(prepare_token_tree).collect(),
             group,

--- a/crates/motoko/src/lib/format.rs
+++ b/crates/motoko/src/lib/format.rs
@@ -564,8 +564,8 @@ fn get_space_between<'a>(a: &'a TokenTree, b: &'a TokenTree) -> RcDoc<'a> {
         (Token(Loc(Operator(s), _)), Token(Loc(Ident(_), _))) if s.eq("#") => nil(),
         (_, Token(Loc(Dot(_), _))) => wrap_(),
         (Token(Loc(Assign(_), _)), _) => wrap(),
-        (_, Group(_, BlockComment, _)) => wrap(),
-        (Group(_, BlockComment, _), _) => wrap(),
+        (_, Group(_, Comment, _)) => wrap(),
+        (Group(_, Comment, _), _) => wrap(),
         _ => space(),
     }
 }
@@ -599,7 +599,7 @@ impl ToDoc for TokenTree {
                     Unenclosed => doc,
                     Curly => enclose_space(open, doc, close),
                     Paren | Square | Angle => enclose(open, doc, close),
-                    BlockComment => RcDoc::as_string(format!("{}", self)),
+                    Comment => RcDoc::as_string(format!("{}", self)),
                 }
             }
         }

--- a/crates/motoko/src/lib/lexer.rs
+++ b/crates/motoko/src/lib/lexer.rs
@@ -98,7 +98,6 @@ fn group_(tokens: &[Loc<Token>]) -> LexResult<Vec<TokenTree>> {
                 let start = i;
                 if let Some(end) = find_closing(g, tokens, i) {
                     i = end;
-                    // println!("{}  ---  {}", tokens[start].0, tokens[end].0); //////////
                     TokenTree::Group(
                         group_(&tokens[start + 1..i])?,
                         g.clone(),
@@ -117,7 +116,6 @@ fn group_(tokens: &[Loc<Token>]) -> LexResult<Vec<TokenTree>> {
 }
 
 fn find_closing(sort: &GroupType, tokens: &[Loc<Token>], start: usize) -> Option<usize> {
-    // println!(">  {:?} {}", sort, start);///////
     let mut i = start + 1;
     let mut depth: usize = 0;
     while i < tokens.len() {
@@ -145,6 +143,5 @@ fn find_closing(sort: &GroupType, tokens: &[Loc<Token>], start: usize) -> Option
         };
         i += 1;
     }
-    // println!("<  {:?} {}", sort, start);///////
     None
 }

--- a/crates/motoko/src/lib/lexer.rs
+++ b/crates/motoko/src/lib/lexer.rs
@@ -126,7 +126,7 @@ fn find_closing(sort: &GroupType, tokens: &[Loc<Token>], start: usize) -> Option
                 depth += 1;
             } else if
             /* sort!=&GroupType::Comment */
-            g == &GroupType::BlockComment {
+            g == &GroupType::Comment {
                 // Skip depth check in block comments
                 if let Some(j) = find_closing(g, tokens, i) {
                     i = j;

--- a/crates/motoko/src/lib/lexer_types.rs
+++ b/crates/motoko/src/lib/lexer_types.rs
@@ -26,18 +26,23 @@ pub enum Token {
     #[regex(r"//[^\n]*", data)]
     LineComment(Data),
 
+    #[regex(r"/\*[^*]*\*/", data)] // precedence
+    BlockComment(Data),
+
     #[token("(", data!(GroupType::Paren))]
     #[token("{", data!(GroupType::Curly))]
     #[token("[", data!(GroupType::Square))]
     #[token("<", data!(GroupType::Angle))]
-    #[token("/*", data!(GroupType::BlockComment))]
+    #[token("/*", data!(GroupType::Comment))]
+    #[token("/**", data!(GroupType::Comment))] // precedence
     Open((Data, GroupType)),
 
     #[token(")", data!(GroupType::Paren))]
     #[token("}", data!(GroupType::Curly))]
     #[token("]", data!(GroupType::Square))]
     #[token(">", data!(GroupType::Angle))]
-    #[token("*/", data!(GroupType::BlockComment))]
+    #[token("*/", data!(GroupType::Comment))]
+    #[token("**/", data!(GroupType::Comment))] // precedence
     Close((Data, GroupType)),
 
     #[token(".", data)]
@@ -101,9 +106,22 @@ impl Token {
         use Token::*;
         match self {
             Error => Err(()),
-            LineComment(s) | Open((s, _)) | Close((s, _)) | Dot(s) | Colon(s) | Assign(s)
-            | Operator(s) | Ident(s) | Wild(s) | Delim((s, _)) | Literal((s, _)) | Space(s)
-            | Line(s) | MultiLine(s) | Unknown(s) => Ok(s),
+            LineComment(s)
+            | BlockComment(s)
+            | Open((s, _))
+            | Close((s, _))
+            | Dot(s)
+            | Colon(s)
+            | Assign(s)
+            | Operator(s)
+            | Ident(s)
+            | Wild(s)
+            | Delim((s, _))
+            | Literal((s, _))
+            | Space(s)
+            | Line(s)
+            | MultiLine(s)
+            | Unknown(s) => Ok(s),
         }
     }
 }
@@ -115,7 +133,7 @@ pub enum GroupType {
     Curly,
     Square,
     Angle,
-    BlockComment,
+    Comment,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -142,7 +160,7 @@ impl GroupType {
             GroupType::Curly => "{",
             GroupType::Square => "[",
             GroupType::Angle => "<",
-            GroupType::BlockComment => "/*",
+            GroupType::Comment => "/*",
         }
     }
     pub fn right_str(&self) -> &'static str {
@@ -152,7 +170,7 @@ impl GroupType {
             GroupType::Curly => "}",
             GroupType::Square => "]",
             GroupType::Angle => ">",
-            GroupType::BlockComment => "*/",
+            GroupType::Comment => "*/",
         }
     }
 }

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.18"
+version = "0.0.19"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 # TODO: set this up as a "workspace dependency"? 
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
-motoko = { path = "../motoko", version = "0.0.18", default-features = false, features = ["parser"] }
+motoko = { path = "../motoko", version = "0.0.19", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"


### PR DESCRIPTION
Fixes several block comment tokenization corner cases related to token precedence between `/*` and `**`, `**=`, etc.