### PR TITLE
Actors distinguish public and private fields.

### DIFF
--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -305,6 +305,15 @@ pub enum Vis {
     System,
 }
 
+impl Vis {
+    pub fn is_public(&self) -> bool {
+        match self {
+            Vis::Public(..) => true,
+            _ => false,
+        }
+    }
+}
+
 pub type Stab_ = Node<Stab>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]

--- a/crates/motoko/src/lib/mod.rs
+++ b/crates/motoko/src/lib/mod.rs
@@ -1,5 +1,3 @@
-#![feature(is_some_with)]
-
 pub mod ast;
 pub mod ast_traversal;
 #[cfg(feature = "parser")]

--- a/crates/motoko/src/lib/mod.rs
+++ b/crates/motoko/src/lib/mod.rs
@@ -1,3 +1,5 @@
+#![feature(is_some_with)]
+
 pub mod ast;
 pub mod ast_traversal;
 #[cfg(feature = "parser")]

--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -414,7 +414,7 @@ ObjBody: DecFields = {
 Vis_: Vis_ = Node<Vis>;
 
 Vis: Vis = {
-  "public" => Vis::Private,
+  "public" => Vis::Public(None),
   "private" => Vis::Private,
 }
 

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -555,6 +555,7 @@ pub enum Interruption {
     EvalInitError(EvalInitError),
     UnboundIdentifer(Id),
     ActorFieldNotFound(ActorId, Id),
+    ActorFieldNotPublic(ActorId, Id),
     AmbiguousIdentifer(Id, Source, Source),
     UnrecognizedPrim(String),
     Limit(Limit),

--- a/crates/motoko/tests/test_actors.rs
+++ b/crates/motoko/tests/test_actors.rs
@@ -44,7 +44,16 @@ fn actor_A_public_func_f_g() {
 }
 
 #[test]
-fn actors_A_public_func_f_fail() {
+fn actor_A_private_func_f_fail() {
+    let i = Interruption::ActorFieldNotPublic(ActorId::Local("A".to_id()), "f".to_id());
+    let p = "
+    actor A { func f () { } };
+    A.f()";
+    assert_x(p, &i);
+}
+
+#[test]
+fn actors_A_missing_func_f_fail() {
     let i = Interruption::ActorFieldNotFound(ActorId::Local("A".to_id()), "f".to_id());
     let p = "
     actor A { };


### PR DESCRIPTION
This PR makes the visibility qualifiers for actor fields relevant and enforced.  Previously, we ignored them.