### PR TITLE
Test Core API.

### DIFF
--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -511,7 +511,7 @@ mod def {
         source: &Source,
         df: &DecField,
     ) -> Result<(), Interruption> {
-        println!("{:?} -- {:?} ", source, df);
+        //println!("{:?} -- {:?} ", source, df);
         match &df.dec.0 {
             Dec::Func(f) => {
                 if let Some(name) = f.name.clone() {
@@ -2387,19 +2387,17 @@ impl Core {
     /// Call an actor method.
     pub fn call(
         &mut self,
-        id: &ActorId,
+        actor: &ActorId,
         method: &Id,
         arg: Value_,
         limits: &Limits,
     ) -> Result<Value_, Interruption> {
         self.assert_idle_agent()?;
-        let fn_v = {
-            let f = self.get_public_actor_field(id, method)?;
-            match &f.def {
-                Def::Func(f) => f.rec_value.fast_clone(),
-                _ => return Err(Interruption::TypeMismatch),
-            }
-        };
+        let fn_v = Value::ActorMethod(ActorMethod {
+            actor: actor.clone(),
+            method: method.clone(),
+        })
+        .share();
         self.stack().push_front(Frame {
             env: HashMap::new(),
             cont: FrameCont::Call2(fn_v, None),

--- a/crates/motoko/tests/test_core.rs
+++ b/crates/motoko/tests/test_core.rs
@@ -1,0 +1,94 @@
+use motoko::ast::ToId;
+use motoko::eval;
+use motoko::shared::Share;
+use motoko::value::ActorId;
+use motoko::vm_types::{Core, Limits};
+use motoko::ToMotoko;
+
+#[test]
+fn actor_upgrade_demo_with_counter_inc() {
+    let mut core = Core::empty();
+    let id = ActorId::Alias("Counter".to_id());
+
+    core.set_actor(
+        id.clone(),
+        "
+      actor {
+        var x = 0;
+        public func get() : async Nat { x };
+        public func inc() { x := x + 1 };
+    }",
+    )
+    .expect("create");
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"get".to_id(),
+            0_u32.to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("0")
+    );
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"inc".to_id(),
+            ().to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("()")
+    );
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"get".to_id(),
+            0_u32.to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("1")
+    );
+
+    core.set_actor(
+        id.clone(),
+        "
+      actor {
+        var x = 0;
+        public func get() : async Nat { x };
+        public func inc() { x := x + 2 };
+    }",
+    )
+    .expect("create");
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"get".to_id(),
+            0_u32.to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("1")
+    );
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"inc".to_id(),
+            ().to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("()")
+    );
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"get".to_id(),
+            0_u32.to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("3")
+    );
+}

--- a/crates/motoko/tests/test_core.rs
+++ b/crates/motoko/tests/test_core.rs
@@ -25,7 +25,7 @@ fn actor_upgrade_demo_with_counter_inc() {
         core.call(
             &id,
             &"get".to_id(),
-            0_u32.to_motoko().unwrap().share(),
+            ().to_motoko().unwrap().share(),
             &Limits::none()
         ),
         eval("0")
@@ -45,7 +45,7 @@ fn actor_upgrade_demo_with_counter_inc() {
         core.call(
             &id,
             &"get".to_id(),
-            0_u32.to_motoko().unwrap().share(),
+            ().to_motoko().unwrap().share(),
             &Limits::none()
         ),
         eval("1")
@@ -66,7 +66,7 @@ fn actor_upgrade_demo_with_counter_inc() {
         core.call(
             &id,
             &"get".to_id(),
-            0_u32.to_motoko().unwrap().share(),
+            ().to_motoko().unwrap().share(),
             &Limits::none()
         ),
         eval("1")
@@ -86,7 +86,7 @@ fn actor_upgrade_demo_with_counter_inc() {
         core.call(
             &id,
             &"get".to_id(),
-            0_u32.to_motoko().unwrap().share(),
+            ().to_motoko().unwrap().share(),
             &Limits::none()
         ),
         eval("3")

--- a/crates/motoko/tests/test_core.rs
+++ b/crates/motoko/tests/test_core.rs
@@ -6,7 +6,7 @@ use motoko::vm_types::{Core, Limits};
 use motoko::ToMotoko;
 
 #[test]
-fn actor_upgrade_demo_with_counter_inc() {
+fn core_set_actor_call() {
     let mut core = Core::empty();
     let id = ActorId::Alias("Counter".to_id());
 


### PR DESCRIPTION
Add unit test for #138.  Fix implementation of `call`, so the unit test is also a regression test.

The unit test scripts the same `Counter` actor upgrade demo, but programmatically, from Rust's view of the type `Core`, rather than from Motoko, as a single `Agent` script.