### PR TITLE
`Interruption::NotOwner`

### DIFF
--- a/crates/motoko/tests/test_actors.rs
+++ b/crates/motoko/tests/test_actors.rs
@@ -2,7 +2,7 @@ use motoko::ast::ToId;
 use motoko::check::assert_vm_eval as assert_;
 use motoko::check::assert_vm_interruption as assert_x;
 use motoko::value::ActorId;
-use motoko::vm_types::{Interruption, NumericPointer, Pointer};
+use motoko::vm_types::{Interruption, LocalPointer, NumericPointer, Pointer, ScheduleChoice};
 
 use test_log::test; // enable logging output for tests by default.
 
@@ -25,7 +25,11 @@ fn actor_a_public_func_f_137() {
 
 #[test]
 fn actor_a_public_func_f_dangling() {
-    let i = Interruption::Dangling(Pointer::Numeric(NumericPointer(0)));
+    let p = Pointer {
+        local: LocalPointer::Numeric(NumericPointer(0)),
+        owner: ScheduleChoice::Agent,
+    };
+    let i = Interruption::NotOwner(p);
     let p = "
     var x = 137;
     actor A { public func f () { x } };

--- a/crates/motoko/tests/test_conversions.rs
+++ b/crates/motoko/tests/test_conversions.rs
@@ -165,7 +165,12 @@ fn roundtrip_value() {
         "#Index(123, #Nat 1)",
         // (123_usize, 1_usize).to_motoko().unwrap(),
         motoko::value::Value::Index(
-            motoko::vm_types::Pointer::Numeric(motoko::vm_types::NumericPointer(123)),
+            motoko::vm_types::Pointer {
+                owner: motoko::vm_types::ScheduleChoice::Agent,
+                local: motoko::vm_types::LocalPointer::Numeric(motoko::vm_types::NumericPointer(
+                    123,
+                )),
+            },
             1_usize.to_motoko().unwrap().share(),
         ),
         "Variant(\"Index\", Some(Tuple([Nat(123), Variant(\"Nat\", Some(Nat(1)))])))",


### PR DESCRIPTION
Interruption for pointer operations on non-owned pointers.

#### Example:

```
var x = 137;
actor A { public func f () { x } };
A.f()
```

Because actor `A` captures a mutable pointer for `x`, its method `f` gets the interruption `NotOwner` when it tries to implicitly dereference `x`, upon being invoked.

Previously, the actor would either:
- say that the pointer is `Dangling` if the numeric or name-based identity does not appear in its store, or much worse
- confuse another actor's pointer with its own, if the pointer happened to be identified the same way.

This PR fixes this previous behavior, which is undesirable and not consistent with the ["actor model"](https://en.wikipedia.org/wiki/Actor_model) of Motoko.