### PR TITLE
More robust actor upgrades.

### DIFF
--- a/crates/motoko/src/lib/dynamic.rs
+++ b/crates/motoko/src/lib/dynamic.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::ast::{Inst, ToId};
 use crate::value::{DynamicValue, Value, Value_};
-use crate::vm_types::{Interruption, Store, CoreSource};
+use crate::vm_types::{CoreSource, Interruption, Store};
 
 pub use dyn_clone::DynClone;
 

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -667,10 +667,12 @@ mod def {
         active.defs().releave_context(&fields, &old_ctx);
         let actor = crate::vm_types::def::Actor { fields };
         match id {
-            ActorId::Alias(x) => {
+            ActorId::Alias(_x) => {
+                /*
                 active
                     .defs()
                     .reinsert_field(&x, source, vis, stab, Def::Actor(actor.clone()))?
+                */
             }
             ActorId::Local(x) => {
                 active

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -375,7 +375,7 @@ impl Store {
                 d.fast_clone().dynamic_mut().set_index(self, index, value)?;
                 Ok(())
             }
-            _ => type_mismatch!(file!(), line!())
+            _ => type_mismatch!(file!(), line!()),
         }
     }
 }
@@ -604,7 +604,7 @@ pub struct Response {
 pub type RespTarget = ScheduleChoice;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq)]
-pub struct OptionCoreSource (pub Option<CoreSource>);
+pub struct OptionCoreSource(pub Option<CoreSource>);
 
 // interruptions are events that prevent steppping from progressing.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -638,7 +638,7 @@ pub enum Interruption {
     IndexOutOfBounds,
     NoDoQuestBangNull,
     MisplacedReturn,
-    NotYetImplemented(CoreSource),
+    NotYetImplemented(CoreSource, Option<String>),
     Unknown,
     Impossible,
     Other(String),
@@ -667,7 +667,7 @@ impl PartialEq for OptionCoreSource {
         match (&self.0, &other.0) {
             (None, _) => true,
             (_, None) => true,
-            (Some(x), Some(y)) => x == y
+            (Some(x), Some(y)) => x == y,
         }
     }
 }

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -93,7 +93,14 @@ pub mod def {
         Actor(Actor),
         Func(Function),
         Value(crate::value::Value_),
-        Var(crate::value::Value_),
+        Var(Var),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+    pub struct Var {
+        pub owner: super::ScheduleChoice,
+        pub name: Id,
+        pub init: crate::value::Value_,
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -104,7 +111,6 @@ pub mod def {
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
     pub struct Actor {
-        //pub context: CtxId,
         pub fields: CtxId,
     }
 
@@ -159,7 +165,7 @@ pub enum Cont {
 }
 
 pub mod stack {
-    use super::{Cont, Env, Pointer, RespTarget, Vector};
+    use super::{def::CtxId, Cont, Env, Pointer, RespTarget, Vector};
     use crate::ast::{
         BinOp, Cases, Dec_, ExpField_, Exp_, Id_, Inst, Mut, Pat_, PrimType, RelOp, Source, Type_,
         UnOp,
@@ -249,6 +255,7 @@ pub mod stack {
     }
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct Frame {
+        pub context: CtxId,
         #[serde(with = "crate::serde_utils::im_rc_hashmap")]
         pub env: Env,
         pub cont: FrameCont,

--- a/crates/motoko/tests/test_actors.rs
+++ b/crates/motoko/tests/test_actors.rs
@@ -48,6 +48,16 @@ fn actor_a_public_func_f_g() {
 }
 
 #[test]
+fn actor_forward_def_func_g() {
+    let p = "
+    let x = 137;
+    actor A { public func f () { g() };
+              public func g () { x }; };
+    A.f()";
+    assert_(p, "137");
+}
+
+#[test]
 fn actor_a_private_func_f_fail() {
     let i = Interruption::ActorFieldNotPublic(ActorId::Local("A".to_id()), "f".to_id());
     let p = "
@@ -150,5 +160,24 @@ fn actor_forward_decl() {
     let p = "
     actor A { public func f () { g() }; public func g() { #ok } };
     A.f()";
+    assert_(p, "#ok");
+}
+
+#[test]
+fn actor_upgrade_fail() {
+    let p = "
+    actor Counter = {
+      var x = 0;
+      public func get() : async Nat { x };
+      public func inc() { x := x + 1 };
+    };
+    actor Counter = {
+      var x = 0;
+      public func get() : async Nat { x };
+      public func inc2() { x := x + 1 };     
+      public func inc() { inc2() };     
+    };
+    Counter.inc();
+    #ok";
     assert_(p, "#ok");
 }

--- a/crates/motoko/tests/test_actors.rs
+++ b/crates/motoko/tests/test_actors.rs
@@ -174,10 +174,47 @@ fn actor_upgrade_fail() {
     actor Counter = {
       var x = 0;
       public func get() : async Nat { x };
-      public func inc2() { x := x + 1 };     
-      public func inc() { inc2() };     
+      public func inc2() { x := x + 1 };
+      public func inc() { inc2() };
     };
     Counter.inc();
+    #ok";
+    assert_(p, "#ok");
+}
+
+#[test]
+fn actor_upgrade_field_ordering1() {
+    let p = "
+    actor Counter = {
+      var x = 0;
+      public func get() : async Nat { x };
+      public func inc() { x := x + 1 };
+    };
+    actor Counter = {
+      var x = 0;
+      public func get() : async Nat { x };
+      public func inc2() { x := x + 1 };
+      public func inc() { inc2() };
+    };
+    Counter.inc();
+    #ok";
+    assert_(p, "#ok");
+}
+
+#[test]
+fn actor_upgrade_field_ordering2() {
+    let p = "
+    actor Counter = {
+      var x = 0;
+      public func get() : async Nat { x };
+      public func inc() { x := x + 1 };
+    };
+    actor Counter = {
+      public func get() : async Nat { x };
+      public func inc() { inc2() };
+      public func inc2() { x := x + 1 };
+      var x = 0;
+    };
     #ok";
     assert_(p, "#ok");
 }

--- a/crates/motoko/tests/test_core.rs
+++ b/crates/motoko/tests/test_core.rs
@@ -5,6 +5,8 @@ use motoko::value::ActorId;
 use motoko::vm_types::{Core, Limits};
 use motoko::ToMotoko;
 
+use test_log::test; // enable logging output for tests by default.
+
 #[test]
 fn core_set_actor_call() {
     let mut core = Core::empty();

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -1,7 +1,7 @@
 use motoko::check::assert_vm_eval as assert_;
 use motoko::check::assert_vm_interruption as assert_x;
-use motoko::vm_types::Interruption;
 use motoko::type_mismatch_;
+use motoko::vm_types::Interruption;
 
 use test_log::test; // enable logging output for tests by default.
 


### PR DESCRIPTION
The VM can handle many more cases of upgrades now, permitting a less constrained set of demos for the dev server:
 - Static definitions are observed and resolved when a variable should resolve that way.
 - Dynamic definitions (of `var` fields) are resolved in a hacky way that is correct for now, but needs to be revisited for actor classes.  The next phase of the solution would store the object or actor reference with each function, so it can resolve those dynamic definitions when they do not appear lexically in the lexical `env`