### PR TITLE
Basic `module` support.

### DIFF
--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -198,6 +198,7 @@ pub type Dec_ = Node<Dec>;
 pub enum Dec {
     Exp(Exp_),
     Let(Pat_, Exp_),
+    LetImport(Pat_, Sugar, String),
     LetModule(Option<Id_>, Sugar, DecFields),
     LetActor(Option<Id_>, Sugar, DecFields),
     Func(Function),
@@ -469,7 +470,8 @@ pub enum Exp {
     Await(Exp_),
     Assert(Exp_),
     Annot(Exp_, Type_),
-    Import(Id_, ResolvedImport),
+    //Import(Id_, ResolvedImport),
+    Import(String),
     Throw(Exp_),
     Try(Exp_, Vec<Case_>),
     Ignore(Exp_),

--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -66,6 +66,7 @@ pub enum Source {
     CoreInit,
     CoreCreateActor,
     CoreUpgradeActor,
+    CoreSetModule,
     CoreCall,
 }
 
@@ -120,6 +121,7 @@ impl std::fmt::Display for Source {
             Source::CoreCreateActor => write!(f, "(Core.create_actor())"),
             Source::CoreUpgradeActor => write!(f, "(Core.upgrade_actor())"),
             Source::CoreCall => write!(f, "(Core.call())"),
+            Source::CoreSetModule => write!(f, "(Core.set_module())"),
         }
     }
 }

--- a/crates/motoko/src/lib/ast_traversal.rs
+++ b/crates/motoko/src/lib/ast_traversal.rs
@@ -301,7 +301,7 @@ impl<'a> Traverse for Loc<&'a Exp> {
                 f(&e.tree());
                 f(&t.tree());
             }
-            Exp::Import(_, _) => {}
+            Exp::Import(..) => {}
             Exp::Throw(e) => f(&e.tree()),
             Exp::Try(e, es) => {
                 f(&e.tree());
@@ -323,6 +323,7 @@ impl<'a> Traverse for Loc<&'a Dec> {
             }
             Dec::LetModule(_, _, _) => todo!(),
             Dec::LetActor(_, _, _) => todo!(),
+            Dec::LetImport(_, _, _) => todo!(),
             Dec::Func(_) => todo!(),
             Dec::Var(p, e) => {
                 f(&p.tree());

--- a/crates/motoko/src/lib/format.rs
+++ b/crates/motoko/src/lib/format.rs
@@ -296,7 +296,7 @@ impl ToDoc for Exp {
             Await(e) => kwd("await").append(e.doc()),
             Assert(e) => kwd("assert").append(e.doc()),
             Annot(e, t) => e.doc().append(" : ").append(t.doc()),
-            Import(s, _) => kwd("import").append(s.doc()), // new permissive syntax?
+            Import(s) => kwd("import").append(s.doc()), // new permissive syntax?
             Throw(e) => kwd("throw").append(e.doc()),
             Try(e, cs) => {
                 let mut doc = kwd("try").append(e.doc());
@@ -335,6 +335,7 @@ impl ToDoc for Dec {
                 .append(e.doc()),
             LetModule(_, _, _) => todo!(),
             LetActor(..) => todo!(),
+            LetImport(..) => todo!(),
             Func(_) => todo!(),
             Var(p, e) => kwd("var")
                 .append(p.doc())

--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -314,6 +314,8 @@ ExpNonDec<B>: Exp = {
     "do" "?" <e:Block_> => Exp::DoOpt(e),
     "assert" <e:ExpNest_> => Exp::Assert(e),
     "debug" <e:ExpNest_> => Exp::Debug(e),
+    "import" <txt:StringLiteral> => Exp::Import(txt),
+
 }
 
 #[inline]
@@ -409,6 +411,7 @@ Dec: Dec = {
 DecNonVar_: Dec_ = Node<DecNonVar>;
 
 DecNonVar: Dec = {
+    "import" <p:PatNullary_> <s:"="?> <txt:StringLiteral> => Dec::LetImport(p, Sugar(s.is_some()), txt),
     "let" <p:Pat_> "=" <e:Exp_<Ob>> => Dec::Let(p, e),
     "module" <i:(Id_)?> <s:"="?> <ob:ObjBody> => Dec::LetModule(i, Sugar(s.is_some()), ob),
     "actor" <i:(Id_)?> <s:"="?> <ob:ObjBody> => Dec::LetActor(i, Sugar(s.is_some()), ob),

--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -11,6 +11,40 @@ use crate::shared::{Share};
 
 grammar(lookup: &LineColLookup<'input>);
 
+
+// Defining operator precedence:
+
+// The compiler's parser generator is able to accept precedence
+// declarations to disambiguate the grammar.
+
+// ```
+// %nonassoc RETURN_NO_ARG IF_NO_ELSE LOOP_NO_WHILE
+// %nonassoc ELSE WHILE
+
+// %left COLON
+// %left OR
+// %left AND
+// %nonassoc EQOP NEQOP LEOP LTOP GTOP GEOP
+// %left ADDOP SUBOP WRAPADDOP WRAPSUBOP HASH
+// %left MULOP WRAPMULOP DIVOP MODOP
+// %left OROP
+// %left ANDOP
+// %left XOROP
+// %nonassoc SHLOP SHROP ROTLOP ROTROP
+// %left POWOP WRAPPOWOP
+// ```
+
+// Here, in LALRPOP, we do not have that affordance.  So, we must encode
+// precedence relationships manually, as manually-stratified productions.
+
+// We do so by creating a production for each line of the declarations above.
+// Productions refer to later ones, but not earlier ones, except in special cases.
+
+// These constructions are effectively each an "expansion" of one of
+// the declarative precedence lines.
+
+
+
 // --- Helper Functions --- //
 
 #[inline]
@@ -490,19 +524,3 @@ DecField_: DecField_ = Node<DecField>;
 DecField: DecField = {
     <vis:(Vis_)?> <stab:(Stab_)?> <dec:Dec_> => DecField{ vis, stab, dec }
 }
-
-// Precedence
-// -----------
-// %nonassoc RETURN_NO_ARG IF_NO_ELSE LOOP_NO_WHILE
-// %nonassoc ELSE WHILE
-// %left COLON
-// %left OR
-// %left AND
-// %nonassoc EQOP NEQOP LEOP LTOP GTOP GEOP
-// %left ADDOP SUBOP WRAPADDOP WRAPSUBOP HASH
-// %left MULOP WRAPMULOP DIVOP MODOP
-// %left OROP
-// %left ANDOP
-// %left XOROP
-// %nonassoc SHLOP SHROP ROTLOP ROTROP
-// %left POWOP WRAPPOWOP

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use crate::ast::{Dec, Decs, Exp, Function, Id, Literal, Mut, ToId};
 use crate::dynamic::Dynamic;
 use crate::shared::{FastClone, Share, Shared};
-use crate::vm_types::{def::Actor as ActorDef, def::CtxId, Env};
+use crate::vm_types::{def::Actor as ActorDef, def::CtxId, def::Module as ModuleDef, Env};
 
 use im_rc::HashMap;
 use im_rc::Vector;
@@ -130,6 +130,7 @@ pub enum Value {
     // DynamicRef(DynamicRef),
     Actor(Actor),
     ActorMethod(ActorMethod),
+    Module(ModuleDef),
 }
 
 /// Actor value.
@@ -504,6 +505,7 @@ impl Value {
             Value::Index(_, _) => Err(ValueError::ToRust("Index".to_string()))?,
             Value::Function(_) => Err(ValueError::ToRust("Function".to_string()))?,
             Value::PrimFunction(_) => Err(ValueError::ToRust("PrimFunction".to_string()))?,
+            Value::Module(_) => Err(ValueError::ToRust("Module".to_string()))?,
             Value::Collection(c) => match c {
                 Collection::HashMap(m) => Array(
                     m.iter()

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -16,7 +16,7 @@ use crate::{Share, Value};
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyntaxError {
     pub path: String,
-    pub code: SyntaxErrorCode
+    pub code: SyntaxErrorCode,
 }
 
 #[macro_export]
@@ -499,6 +499,7 @@ pub struct Core {
     pub actors: Actors,
     pub next_resp_id: usize,
     pub debug_print_out: Vector<DebugPrintLine>,
+    pub paths: Paths,
 }
 
 /// The current/last/next schedule choice, depending on context.
@@ -513,6 +514,24 @@ pub enum ScheduleChoice {
 pub struct Actors {
     #[serde(with = "crate::serde_utils::im_rc_hashmap")]
     pub map: HashMap<ActorId, Actor>,
+}
+
+/// The Paths in a Core system (a virtual filesystem).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Paths {
+    #[serde(with = "crate::serde_utils::im_rc_hashmap")]
+    pub map: HashMap<Path, File>,
+}
+
+/// A Path should adhere to certain rules, not enforced by this type.
+pub type Path = String;
+
+/// The File in a Core system (a virtual filesystem).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct File {
+    pub content: String,
+    /// Each file is a root in the definition database forest.
+    pub def_ctx: def::CtxId,
 }
 
 /// A line of output emitted by prim "debugPrint".

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -101,7 +101,7 @@ pub mod def {
         Var(Var),
         /// We represent "static values" as expressions.
         /// (to permit variables that mention other static values.)
-        StaticValue(super::Exp_),
+        StaticValue(CtxId, super::Exp_),
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -674,6 +674,7 @@ pub enum Interruption {
     Dangling(Pointer),
     NotOwner(Pointer),
     ModuleNotStatic(Source),
+    ModuleFieldNotPublic,
     TypeMismatch(OptionCoreSource),
     NonLiteralInit(Source),
     NoMatchingCase,

--- a/crates/motoko/tests/test_modules.rs
+++ b/crates/motoko/tests/test_modules.rs
@@ -26,7 +26,8 @@ fn module() {
     assert M.x4 == #foo(#foo(#foo(3)));
     assert M.x5 == #foo(3);
     assert M.x6 == #foo(#foo(3));
-    assert M.x7[0] == 1;8 == 0;";
+    assert M.x7[0] == 1;
+    assert M.x8 == 0;";
     assert_(p, p)
 }
 

--- a/crates/motoko/tests/test_modules.rs
+++ b/crates/motoko/tests/test_modules.rs
@@ -1,0 +1,22 @@
+use motoko::check::assert_vm_eval as assert_;
+//use motoko::check::assert_vm_interruption as assert_x;
+
+use test_log::test; // enable logging output for tests by default.
+
+#[test]
+fn module() {
+    let p = "module X { public let x = y; let y = (f 1, 2); func f () { } }";
+    assert_(p, p)
+}
+
+#[test]
+fn import_nothing() {
+    let p = "import _ = \"Module\"";
+    assert_(p, "()")
+}
+
+#[test]
+fn import_something() {
+    let p = "import M \"Module\"";
+    assert_(p, "()")
+}

--- a/crates/motoko/tests/test_modules.rs
+++ b/crates/motoko/tests/test_modules.rs
@@ -7,24 +7,26 @@ use test_log::test; // enable logging output for tests by default.
 fn module() {
     let p = "
     module M {
-      public let x1 = y;
-      let x2 = (1, 2);
-      func x3 () { };
+      public let x1 = x2;
+      public let x2 = (1, 2);
+      public func x3 () { };
       let _ = 1 + 2 - 4;
       1 + 2 - 4;
       public 1 + 2 - 4;
       public let x4 = #foo(x6);
       public let x5 = #foo(1 + 2);
       public let x6 = #foo(x5);
-      let x7 = [1, 2];
+      public let x7 = [1, 2];
+      public let x8 = z;
+      let z = 0;
     };
-    M.x1;
-    M.x2;
-    M.x3;
-    M.x4;
-    M.x5;
-    M.x6;
-    M.x7;";
+    assert M.x1.0 == 1;
+    assert M.x2.0 == 1;
+    assert M.x3 () == ();
+    assert M.x4 == #foo(#foo(#foo(3)));
+    assert M.x5 == #foo(3);
+    assert M.x6 == #foo(#foo(3));
+    assert M.x7[0] == 1;8 == 0;";
     assert_(p, p)
 }
 

--- a/crates/motoko/tests/test_modules.rs
+++ b/crates/motoko/tests/test_modules.rs
@@ -5,16 +5,37 @@ use test_log::test; // enable logging output for tests by default.
 
 #[test]
 fn module() {
-    let p = "module X { public let x = y; let y = (f 1, 2); func f () { } }";
+    let p = "
+    module M {
+      public let x1 = y;
+      let x2 = (1, 2);
+      func x3 () { };
+      let _ = 1 + 2 - 4;
+      1 + 2 - 4;
+      public 1 + 2 - 4;
+      public let x4 = #foo(x6);
+      public let x5 = #foo(1 + 2);
+      public let x6 = #foo(x5);
+      let x7 = [1, 2];
+    };
+    M.x1;
+    M.x2;
+    M.x3;
+    M.x4;
+    M.x5;
+    M.x6;
+    M.x7;";
     assert_(p, p)
 }
 
+#[ignore]
 #[test]
 fn import_nothing() {
     let p = "import _ = \"Module\"";
     assert_(p, "()")
 }
 
+#[ignore]
 #[test]
 fn import_something() {
     let p = "import M \"Module\"";

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -251,13 +251,6 @@ fn for_() {
         "var x = 13; var c = 0; let i = { next = func () { if (x == 0) { null } else { x := x - 1; c := c + 1; ?x } } }; for (j in i) { let _ = j; }; c", "13");
 }
 
-#[ignore]
-#[test]
-fn module() {
-    let p = "module X { public let x = 5; let y = (1, 2); func f () { } }";
-    assert_(p, p)
-}
-
 #[test]
 fn prim_debug_print() {
     assert_("prim \"debugPrint\" \"hello, world\"", "()");


### PR DESCRIPTION
This PR was originally going to do imports and modules, but it's getting large and complex by just doing the latter.

The current scope is:
- Module definitions
- Module projections

With `import` and tests for it coming in a later PR.