### PR TITLE
Add conversion from Candid to Motoko values

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -32,6 +32,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 # serde_with = "2.0.1"
 test-log = "0.2.11"
 dyn-clone = "1.0.9"
+candid = "0.8.4"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/crates/motoko/src/lib/candid_utils.rs
+++ b/crates/motoko/src/lib/candid_utils.rs
@@ -27,7 +27,6 @@ pub fn to_value(value: IDLValue) -> Result<Value> {
         IDLValue::Bool(b) => Value::Bool(b),
         IDLValue::Null => Value::Null,
         IDLValue::Text(t) => Value::Text(t.into()),
-        // IDLValue::Number(n) => Value::,
         IDLValue::Opt(o) => Value::Option(to_value(*o)?.share()),
         IDLValue::Vec(v) => Value::Array(
             Mut::Const,

--- a/crates/motoko/src/lib/candid_utils.rs
+++ b/crates/motoko/src/lib/candid_utils.rs
@@ -1,0 +1,84 @@
+use candid::parser::value::{IDLArgs, IDLValue, VariantValue};
+use candid::types::Label;
+use im_rc::{HashMap, Vector};
+
+use crate::ast::{Id, Mut, ToId};
+use crate::value::{FieldValue, Result};
+use crate::{Share, Value, ValueError};
+
+fn resolve_id(label: Label) -> Result<Id> {
+    use candid::types::Label::*;
+    Ok(match label {
+        // TODO: implement `Id` and `Unnamed` keys
+        Id(i) => Err(ValueError::ToMotoko(format!(
+            "Candid: cannot convert `Id` ({}) to field name",
+            i
+        )))?,
+        Named(s) => s.to_id(),
+        Unnamed(i) => Err(ValueError::ToMotoko(format!(
+            "Candid: cannot convert `Unnamed` ({}) to field name",
+            i
+        )))?,
+    })
+}
+
+pub fn to_value(value: IDLValue) -> Result<Value> {
+    Ok(match value {
+        IDLValue::Bool(b) => Value::Bool(b),
+        IDLValue::Null => Value::Null,
+        IDLValue::Text(t) => Value::Text(t.into()),
+        // IDLValue::Number(n) => Value::,
+        IDLValue::Opt(o) => Value::Option(to_value(*o)?.share()),
+        IDLValue::Vec(v) => Value::Array(
+            Mut::Const,
+            v.into_iter()
+                .map(|v| to_value(v).map(|v| v.share()))
+                .collect::<Result<_>>()?,
+        ),
+        IDLValue::Record(r) => Value::Object({
+            let mut map = HashMap::new();
+            for field in r {
+                map.insert(
+                    resolve_id(field.id)?,
+                    FieldValue {
+                        mut_: Mut::Const,
+                        val: to_value(field.val)?.share(),
+                    },
+                );
+            }
+            map
+        }), // TODO: refactor `motoko::Value::Object` to `motoko::Value::Record`?
+        IDLValue::Variant(VariantValue(field, _)) => {
+            Value::Variant(resolve_id(field.id)?, Some(to_value(field.val)?.share()))
+        }
+        IDLValue::Principal(_) => todo!(), // TODO
+        IDLValue::Service(_) => todo!(),   // TODO
+        IDLValue::Func(_, _) => todo!(),
+        IDLValue::None => Value::Null,
+        IDLValue::Nat(i) => Value::Nat(i.0),
+        IDLValue::Nat8(i) => Value::Nat(i.into()),  // TODO
+        IDLValue::Nat16(i) => Value::Nat(i.into()), // TODO
+        IDLValue::Nat32(i) => Value::Nat(i.into()), // TODO
+        IDLValue::Nat64(i) => Value::Nat(i.into()), // TODO
+        IDLValue::Int(i) => Value::Int(i.0),
+        IDLValue::Int8(i) => Value::Int(i.into()),  // TODO
+        IDLValue::Int16(i) => Value::Int(i.into()), // TODO
+        IDLValue::Int32(i) => Value::Int(i.into()), // TODO
+        IDLValue::Int64(i) => Value::Int(i.into()), // TODO
+        IDLValue::Float32(f) => Value::Float((f as f64).into()), // TODO: 32-bit float values?
+        IDLValue::Float64(f) => Value::Float(f.into()),
+        IDLValue::Number(n) => Err(ValueError::ToMotoko(n))?, // TODO
+        IDLValue::Reserved => Err(ValueError::ToMotoko("Reserved Candid value".to_string()))?,
+    })
+}
+
+pub fn decode_candid_args(bytes: &[u8]) -> Result<Value> {
+    let args = IDLArgs::from_bytes(bytes).map_err(ValueError::Candid)?;
+
+    Ok(Value::Tuple(
+        args.args
+            .into_iter()
+            .map(|v| to_value(v).map(|v| v.share()))
+            .collect::<Result<_>>()?,
+    ))
+}

--- a/crates/motoko/src/lib/candid_utils.rs
+++ b/crates/motoko/src/lib/candid_utils.rs
@@ -73,7 +73,7 @@ pub fn to_value(value: IDLValue) -> Result<Value> {
 }
 
 pub fn decode_candid_args(bytes: &[u8]) -> Result<Value> {
-    let args = IDLArgs::from_bytes(bytes).map_err(ValueError::Candid)?;
+    let args = IDLArgs::from_bytes(bytes).map_err(|e| ValueError::Candid(e.to_string()))?;
 
     Ok(Value::Tuple(
         args.args

--- a/crates/motoko/src/lib/candid_utils.rs
+++ b/crates/motoko/src/lib/candid_utils.rs
@@ -50,9 +50,9 @@ pub fn to_value(value: IDLValue) -> Result<Value> {
         IDLValue::Variant(VariantValue(field, _)) => {
             Value::Variant(resolve_id(field.id)?, Some(to_value(field.val)?.share()))
         }
-        IDLValue::Principal(_) => todo!(), // TODO
-        IDLValue::Service(_) => todo!(),   // TODO
-        IDLValue::Func(_, _) => todo!(),
+        IDLValue::Principal(_) => Err(ValueError::Candid("TODO: Principal".to_string()))?,
+        IDLValue::Service(_) => Err(ValueError::Candid("TODO: Service".to_string()))?,
+        IDLValue::Func(_, _) => Err(ValueError::Candid("TODO: Func".to_string()))?,
         IDLValue::None => Value::Null,
         IDLValue::Nat(i) => Value::Nat(i.0),
         IDLValue::Nat8(i) => Value::Nat(i.into()),  // TODO

--- a/crates/motoko/src/lib/candid_utils.rs
+++ b/crates/motoko/src/lib/candid_utils.rs
@@ -1,6 +1,6 @@
 use candid::parser::value::{IDLArgs, IDLValue, VariantValue};
 use candid::types::Label;
-use im_rc::{HashMap, Vector};
+use im_rc::HashMap;
 
 use crate::ast::{Id, Mut, ToId};
 use crate::value::{FieldValue, Result};

--- a/crates/motoko/src/lib/mod.rs
+++ b/crates/motoko/src/lib/mod.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 pub mod ast_traversal;
+pub mod candid_utils;
 #[cfg(feature = "parser")]
 pub mod check;
 pub mod convert;

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -659,7 +659,7 @@ pub enum ValueError {
     Float,
     ToRust(String),
     ToMotoko(String),
-    Candid(candid::Error),
+    Candid(String),
     NotAValue,
 }
 

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -659,6 +659,7 @@ pub enum ValueError {
     Float,
     ToRust(String),
     ToMotoko(String),
+    Candid(candid::Error),
     NotAValue,
 }
 


### PR DESCRIPTION
This PR implements a `candid_utils::decode_candid_args()` function required for the Motoko Dev Server.