### PR TITLE
Generalize object syntax

### DIFF
--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -557,23 +557,16 @@ impl Exp {
         Exp::Object(None, Some(fields))
     }
     pub fn obj_base_bases(base1: Exp_, bases: Option<Delim<Exp_>>, efs: Option<ExpFields>) -> Exp {
-        match bases {
-            None => match &base1.0 {
+        match (bases, efs) {
+            (None, None) => match &base1.0 {
                 Exp::Var(x) => {
                     let x = NodeData(x.clone(), base1.1.clone()).share();
-                    match (bases, efs) {
-                        (None, None) => Exp::obj_id_fields(x, Delim::new()),
-                        (None, Some(fields)) => Exp::obj_id_fields(x, fields),
-                        (Some(bases), efs) => {
-                            let mut bases = bases;
-                            bases.vec.push_front(base1);
-                            Exp::Object(Some(bases), efs)
-                        }
-                    }
+                    Exp::obj_id_fields(x, Delim::new())
                 }
                 _ => unimplemented!("parse error"),
             },
-            Some(mut bs) => {
+            (None, efs) => Exp::Object(Some(Delim::one(base1)), efs),
+            (Some(mut bs), efs) => {
                 bs.vec.push_front(base1);
                 Exp::Object(Some(bs), efs)
             }

--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -278,7 +278,7 @@ pub struct ExpField {
     pub mut_: Mut,
     pub id: Id_,
     pub typ: Option<Type_>,
-    pub exp: Exp_,
+    pub exp: Option<Exp_>,
 }
 
 pub type DecField_ = Node<DecField>;

--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -539,24 +539,42 @@ impl Exp {
             }
         }
     }
-    pub fn obj_id_fields(id: Id_, fs: ExpFields) -> Exp {
-        todo!()
-        /*
-                let field1_source = id.0.clone();
-                let field1 = (Field{ Mut::Const, id, exp:None, typ:None }, field1_source).share();
-                let mut fields = fields;
-                fields.vec.push_front(field1);
-                Exp::Object(None, None, fields)
-        */
+    pub fn obj_id_fields(id: Id_, fields: ExpFields) -> Exp {
+        let field1_source = id.1.clone();
+        let exp = Some(NodeData(Exp::Var(id.0.clone()), id.1.clone()).share());
+        let field1 = NodeData(
+            ExpField {
+                mut_: Mut::Const,
+                id,
+                exp,
+                typ: None,
+            },
+            field1_source,
+        )
+        .share();
+        let mut fields = fields;
+        fields.vec.push_front(field1);
+        Exp::Object(None, Some(fields))
     }
-    pub fn obj_base_bases(base: Exp_, bases: Option<Delim<Exp_>>, efs: Option<ExpFields>) -> Exp {
+    pub fn obj_base_bases(base1: Exp_, bases: Option<Delim<Exp_>>, efs: Option<ExpFields>) -> Exp {
         match bases {
-            None => match &base.0 {
-                Exp::Var(x) => todo!(),
+            None => match &base1.0 {
+                Exp::Var(x) => {
+                    let x = NodeData(x.clone(), base1.1.clone()).share();
+                    match (bases, efs) {
+                        (None, None) => Exp::obj_id_fields(x, Delim::new()),
+                        (None, Some(fields)) => Exp::obj_id_fields(x, fields),
+                        (Some(bases), efs) => {
+                            let mut bases = bases;
+                            bases.vec.push_front(base1);
+                            Exp::Object(Some(bases), efs)
+                        }
+                    }
+                }
                 _ => unimplemented!("parse error"),
             },
             Some(mut bs) => {
-                bs.vec.push_front(base);
+                bs.vec.push_front(base1);
                 Exp::Object(Some(bs), efs)
             }
         }

--- a/crates/motoko/src/lib/ast_traversal.rs
+++ b/crates/motoko/src/lib/ast_traversal.rs
@@ -427,7 +427,8 @@ impl<'a> Traverse for Loc<&'a ExpField> {
         if let Some(t) = &self.0.typ {
             f(&t.tree());
         }
-        f(&self.0.exp.tree());
+        //f(&self.0.exp.tree());
+        todo!()
     }
 }
 

--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -405,21 +405,20 @@ ExpUn<B>: Exp = {
     "from_candid" <e:ExpUn_<B>> => Exp::FromCandid(e),
 }
 
-#[inline]
-ExpBase_: Exp_ = Node<ExpBase>;
-
-// to do -- first base should actually be ExpPost_<Bl>,
-// but this grammar leads to shift-reduce conflicts with lalrpop.
-ExpBase: Exp = {
-    ExpPlain,
-    ExpObj,
-}
-
 ExpObj: Exp = {
-    "{" <fs:Delim0<ExpField_, ";">> "}" => Exp::Object(None, None, Some(fs)),
-    "{" <base:ExpBase_> <bases:("and" <Delim1<ExpPost_<Bl>, "and">>)?> <efs:("with" <Delim1<ExpField_, ";">>)?> "}" => {
+//    "{" <fs:Delim0<ExpField_, ";">> "}" => Exp::Object(None, None, Some(fs)),
+    "{" <base1:ExpPost_<Ob>> <bases:("and" <Delim1<ExpPost_<Ob>, "and">>)?> <efs:("with" <Delim1<ExpField_, ";">>)?> "}" => {
         Exp::Object(Some(base), bases, efs)
     },
+    "{" "var" Id (":" TypeNoBin)? "=" ExpIfNoElse_<Exp<Ob>> (";" <Delim0<ExpField_, ";">>)? "}" => todo!(),
+    "{" Id ":" TypeNoBin ("=" ExpIfNoElse_<Exp<Ob>>)? (";" <Delim0<ExpField_, ";">>)? "}" => todo!(),
+    "{" <field1:ExpPost_<Ob>> ";" <fields:Delim1<ExpField_, ";">> "}" => {
+        // we cannot parse field1 directly as a FieldExp, like the ones that may follow it.  It is ambiguous.
+        // this limitation comes from LALR(1) of lalrpop in contrast to LR(1) of menhir.
+        // so, we need to parse field1 as an ExpPost, and the other cases not covered by ExpPost, rather than directly as a FieldExp.
+        // syntax error if "field1" cannot be re-parsed as a Field (most forms of ExpPost<Ob> are inappropriate here; only Var is appropriate.)
+        todo!() 
+    }
 }
 
 #[inline]
@@ -579,7 +578,7 @@ Case: Case = {
 ExpField_: Node<ExpField> = Node<ExpField>;
 
 ExpField: ExpField = {
-    <mut_:VarOpt> <id:Id_> <typ:(":" <Type_>)?> "=" <exp:ExpIfNoElse_<Exp<Ob>>> => ExpField{ mut_, id, exp, typ }
+    <mut_:VarOpt> <id:Id_> <typ:(":" <Type_>)?> <exp:("=" <ExpIfNoElse_<Exp<Ob>>>)?> => ExpField{ mut_, id, exp, typ }
 }
 
 Decs: Decs = {

--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -408,25 +408,39 @@ ExpUn<B>: Exp = {
 ExpObj: Exp = {
     // Object syntax.
     //
-    // We want to use this concise rule, like in the Menhir version of the Motoko parser:
+    // We want to use this concise rule, like in the Menhir version of
+    // the Motoko parser:
     //
     //    "{" <fs:Delim0<ExpField_, ";">> "}" => Exp::Object(None, None, Some(fs)),
     //
-    // But, we cannot parse field1 directly as a FieldExp, like the ones that may follow it.  It is ambiguous here, sadly.
-    // (It conflicts with the new rules for record base-extension syntax, in the singleton-var case `{ x }`).
-    // This limitation comes from the LALR(1) language of lalrpop in contrast to the LR(1) language of menhir.
-    // To bridge this gap, we parse field1 in a case-by-case way.
+    // But, we cannot parse the first field directly as a FieldExp,
+    // like the ones that may follow it.  It is ambiguous here, sadly.
+    // (It conflicts with the new rules for record base-extension
+    // syntax, in the singleton-var case `{ x }`).  This limitation
+    // comes from the LALR(1) language of lalrpop in contrast to the
+    // LR(1) language of menhir.  To bridge this gap, we parse the
+    // first field in a more case-by-case way.
     //
-    "{" "var" Id (":" TypeNoBin)? "=" ExpIfNoElse_<Exp<Ob>> (";" <Delim0<ExpField_, ";">>)? "}" => todo!(),
-    "{" Id ":" TypeNoBin ("=" ExpIfNoElse_<Exp<Ob>>)? (";" <Delim0<ExpField_, ";">>)? "}" => todo!(),
-    "{" Id ";" <fields:Delim1<ExpField_, ";">> "}" => {
-        todo!() 
-    }
-    "{" <base1:ExpPost_<Ob>> <bases:("and" <Delim1<ExpPost_<Ob>, "and">>)?> <efs:("with" <Delim1<ExpField_, ";">>)?> "}" => {
-        // when base1=Var(x) and bases=None and efs=None, we need to "re-parse" to help overcome the ambiguity described above.
-        Exp::Object(Some(base), bases, efs)
-    },
+    "{" "}" => Exp::Object(None, None),
+    "{" <field1:ExpFieldNoBareId_> <fields:(";" <Delim0<ExpField_, ";">>)?> "}" => Exp::obj_field_fields(field1, fields),
+    "{" <id:Id_> ";" <fields:Delim1<ExpField_, ";">> "}" => Exp::obj_id_fields(id, fields),
+    "{" <base1:ExpPost_<Ob>> <bases:("and" <Delim1<ExpPost_<Ob>, "and">>)?> <efs:("with" <Delim1<ExpField_, ";">>)?> "}" => Exp::obj_base_bases(base1, bases, efs),
+}
 
+#[inline]
+ExpField_: Node<ExpField> = Node<ExpField>;
+
+ExpField: ExpField = {
+    <mut_:VarOpt> <id:Id_> <typ:(":" <Type_>)?> <exp:("=" <ExpIfNoElse_<Exp<Ob>>>)?> => ExpField{ mut_, id, exp, typ }
+}
+
+#[inline]
+ExpFieldNoBareId_: Node<ExpField> = Node<ExpFieldNoBareId>;
+
+ExpFieldNoBareId: ExpField = { // like ExpField, except that a "bare" Id is not permitted.  Helps disambiguate the parse tree.
+    "var" <id:Id_> <typ:(":" <TypeNoBin_>)?> "=" <exp:ExpIfNoElse_<Exp<Ob>>> => ExpField{ mut_:Mut::Var, id, exp:Some(exp), typ },
+    <id:Id_> ":" <typ:TypeNoBin_> <exp:("=" <ExpIfNoElse_<Exp<Ob>>>)?> => ExpField{ mut_:Mut::Const, id, exp, typ:Some(typ) },
+    <id:Id_> "=" <exp:ExpIfNoElse_<Exp<Ob>>> => ExpField{ mut_:Mut::Const, id, exp:Some(exp), typ:None },
 }
 
 #[inline]
@@ -580,13 +594,6 @@ Cases: Cases = {
 
 Case: Case = {
     "case" <pat:PatNullary_> <exp:ExpIfNoElse_<ExpNest>> => Case{pat, exp},
-}
-
-#[inline]
-ExpField_: Node<ExpField> = Node<ExpField>;
-
-ExpField: ExpField = {
-    <mut_:VarOpt> <id:Id_> <typ:(":" <Type_>)?> <exp:("=" <ExpIfNoElse_<Exp<Ob>>>)?> => ExpField{ mut_, id, exp, typ }
 }
 
 Decs: Decs = {

--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -406,19 +406,27 @@ ExpUn<B>: Exp = {
 }
 
 ExpObj: Exp = {
-//    "{" <fs:Delim0<ExpField_, ";">> "}" => Exp::Object(None, None, Some(fs)),
-    "{" <base1:ExpPost_<Ob>> <bases:("and" <Delim1<ExpPost_<Ob>, "and">>)?> <efs:("with" <Delim1<ExpField_, ";">>)?> "}" => {
-        Exp::Object(Some(base), bases, efs)
-    },
+    // Object syntax.
+    //
+    // We want to use this concise rule, like in the Menhir version of the Motoko parser:
+    //
+    //    "{" <fs:Delim0<ExpField_, ";">> "}" => Exp::Object(None, None, Some(fs)),
+    //
+    // But, we cannot parse field1 directly as a FieldExp, like the ones that may follow it.  It is ambiguous here, sadly.
+    // (It conflicts with the new rules for record base-extension syntax, in the singleton-var case `{ x }`).
+    // This limitation comes from the LALR(1) language of lalrpop in contrast to the LR(1) language of menhir.
+    // To bridge this gap, we parse field1 in a case-by-case way.
+    //
     "{" "var" Id (":" TypeNoBin)? "=" ExpIfNoElse_<Exp<Ob>> (";" <Delim0<ExpField_, ";">>)? "}" => todo!(),
     "{" Id ":" TypeNoBin ("=" ExpIfNoElse_<Exp<Ob>>)? (";" <Delim0<ExpField_, ";">>)? "}" => todo!(),
-    "{" <field1:ExpPost_<Ob>> ";" <fields:Delim1<ExpField_, ";">> "}" => {
-        // we cannot parse field1 directly as a FieldExp, like the ones that may follow it.  It is ambiguous.
-        // this limitation comes from LALR(1) of lalrpop in contrast to LR(1) of menhir.
-        // so, we need to parse field1 as an ExpPost, and the other cases not covered by ExpPost, rather than directly as a FieldExp.
-        // syntax error if "field1" cannot be re-parsed as a Field (most forms of ExpPost<Ob> are inappropriate here; only Var is appropriate.)
+    "{" Id ";" <fields:Delim1<ExpField_, ";">> "}" => {
         todo!() 
     }
+    "{" <base1:ExpPost_<Ob>> <bases:("and" <Delim1<ExpPost_<Ob>, "and">>)?> <efs:("with" <Delim1<ExpField_, ";">>)?> "}" => {
+        // when base1=Var(x) and bases=None and efs=None, we need to "re-parse" to help overcome the ambiguity described above.
+        Exp::Object(Some(base), bases, efs)
+    },
+
 }
 
 #[inline]

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -1709,11 +1709,8 @@ fn exp_step<A: Active>(active: &mut A, exp: Exp_) -> Result<Step, Interruption> 
         ),
         Do(e) => exp_conts(active, FrameCont::Do, e),
         Assert(e) => exp_conts(active, FrameCont::Assert, e),
-        Object(base, more_bases, fields) => {
-            if let Some(base) = base {
-                return nyi!(line!());
-            };
-            if let Some(more_bases) = more_bases {
+        Object(bases, fields) => {
+            if let Some(bases) = bases {
                 return nyi!(line!());
             };
             if let Some(fields) = fields {
@@ -1729,11 +1726,16 @@ fn exp_step<A: Active>(active: &mut A, exp: Exp_) -> Result<Step, Interruption> 
                             id: f1.0.id.fast_clone(),
                             typ: f1.0.typ.fast_clone(),
                         };
-                        exp_conts(active, FrameCont::Object(Vector::new(), fc, fs), &f1.0.exp)
+                        exp_conts(
+                            active,
+                            FrameCont::Object(Vector::new(), fc, fs),
+                            &f1.0.exp_(),
+                        )
                     }
                 }
             } else {
-                return nyi!(line!());
+                *active.cont() = cont_value(Value::Object(HashMap::new()));
+                Ok(Step {})
             }
         }
         Tuple(es) => {
@@ -2328,7 +2330,7 @@ fn nonempty_stack_cont<A: Active>(active: &mut A, v: Value_) -> Result<Step, Int
                         },
                         rest,
                     ),
-                    &next.0.exp,
+                    &next.0.exp_(),
                 ),
             }
         }

--- a/crates/motoko/tests/test_parser.rs
+++ b/crates/motoko/tests/test_parser.rs
@@ -22,15 +22,14 @@ fn test_dot_dot() {
     assert_parse_ok("foo.0.1.0.1.0.1");
 }
 
-#[ignore]
 #[test]
 fn test_type_decl() {
-    assert_("type T = ()");
-    assert_("type T = {}"); // note that "{} cannot produce type ()".
-    assert_("type T = {#banana}");
-    assert_("type T = {#banana : Nat}");
-    assert_("type T = {banana : Nat}");
-    assert_("type T = {banana : Nat, apple : Text}");
+    assert_parse_ok("type T = ()");
+    assert_parse_ok("type T = {}"); // note that "{} cannot produce type ()".
+    assert_parse_ok("type T = {#banana}");
+    assert_parse_ok("type T = {#banana : Nat}");
+    assert_parse_ok("type T = {banana : Nat}");
+    assert_parse_ok("type T = {banana : Nat; apple : Text}");
 }
 
 #[test]
@@ -79,14 +78,13 @@ fn test_query_shared_func_err() {
     assert_parse_err("actor { public query shared func f() : async Nat { 1 } }");
 }
 
-#[ignore]
 #[test]
 fn test_option() {
     assert_("?1");
     assert_("?()");
     assert_("?(1)");
     assert_("?(1, 2,)");
-    assert_("?{ }");
+    assert_parse_ok("?{ }");
     assert_("?#apple");
 }
 
@@ -248,13 +246,12 @@ fn test_var_array() {
     assert_("[var 1, 2,]");
 }
 
-#[ignore]
 #[test]
 fn test_let_var() {
     assert_("let x = 0; x");
-    assert_("let x : Int = 0; x");
-    assert_("var x = 0; x");
-    assert_("var x : Int = 0; x");
+    assert_parse_ok("let x : Int = 0; x");
+    assert_parse_ok("var x = 0; x");
+    assert_parse_ok("var x : Int = 0; x");
 }
 
 #[test]
@@ -279,14 +276,13 @@ fn test_variant() {
     }
 }
 
-#[ignore]
 #[test]
 fn test_record() {
-    assert_("{ }");
+    assert_parse_ok("{ }");
     //assert_("{ ; }"); // 2022-08-05 <-- corner case. what to do here?
-    assert_("{ foo = 3; }");
-    assert_("{ foo : Nat = 3; }");
-    assert_("{ foo : Nat = 3; bar = #apple }");
+    assert_parse_ok("{ foo = 3; }");
+    assert_parse_ok("{ foo : Nat = 3; }");
+    assert_parse_ok("{ foo : Nat = 3; bar = #apple }");
 }
 
 #[test]
@@ -353,11 +349,10 @@ fn test_record_proj() {
     assert_to("x . foo", "x.foo");
 }
 
-#[ignore]
 #[test]
 fn test_tuple_proj() {
-    assert_("x.0");
-    assert_to("x . 0", "x.0");
+    assert_parse_ok("x.0");
+    assert_parse_ok("x . 0");
 }
 
 #[test]

--- a/crates/motoko/tests/test_parser.rs
+++ b/crates/motoko/tests/test_parser.rs
@@ -280,6 +280,7 @@ fn test_variant() {
 fn test_record() {
     assert_parse_ok("{ }");
     assert_parse_ok("{ x }");
+    assert_parse_ok("{ x : Nat }");
     assert_parse_ok("{ x = 3 }");
     assert_parse_ok("{ x = 3; }");
     assert_parse_ok("{ x with y = 3 }");
@@ -291,6 +292,7 @@ fn test_record() {
     assert_parse_ok("{ var x = 3; var y = #apple }");
     assert_parse_ok("{ var x = 3; y }");
     assert_parse_ok("{ x; y }");
+    assert_parse_ok("{ x with z = 3}");
     assert_parse_ok("{ f x with z = 3}");
     assert_parse_ok(
         "

--- a/crates/motoko/tests/test_parser.rs
+++ b/crates/motoko/tests/test_parser.rs
@@ -279,10 +279,26 @@ fn test_variant() {
 #[test]
 fn test_record() {
     assert_parse_ok("{ }");
-    //assert_("{ ; }"); // 2022-08-05 <-- corner case. what to do here?
-    assert_parse_ok("{ foo = 3; }");
-    assert_parse_ok("{ foo : Nat = 3; }");
-    assert_parse_ok("{ foo : Nat = 3; bar = #apple }");
+    assert_parse_ok("{ x }");
+    assert_parse_ok("{ x = 3 }");
+    assert_parse_ok("{ x = 3; }");
+    assert_parse_ok("{ x with y = 3 }");
+    assert_parse_ok("{ x and y with z = 3 }");
+    assert_parse_ok("{ f x and f y with z = 3 }");
+    assert_parse_ok("{ x : Nat = 3; }");
+    assert_parse_ok("{ x : Nat = 3; y = #apple }");
+    assert_parse_ok("{ var x : Nat = 3; var y = #apple }");
+    assert_parse_ok("{ var x = 3; var y = #apple }");
+    assert_parse_ok("{ var x = 3; y }");
+    assert_parse_ok("{ x; y }");
+    assert_parse_ok(
+        "
+      func f () : { x : Nat } = { x = 3 };
+      func g () : { y : Nat } = { y = 3 };
+      let (x, y) = ((), ());
+      { f x and g y with z = 3 };
+    ",
+    );
 }
 
 #[test]

--- a/crates/motoko/tests/test_parser.rs
+++ b/crates/motoko/tests/test_parser.rs
@@ -291,6 +291,7 @@ fn test_record() {
     assert_parse_ok("{ var x = 3; var y = #apple }");
     assert_parse_ok("{ var x = 3; y }");
     assert_parse_ok("{ x; y }");
+    assert_parse_ok("{ f x with z = 3}");
     assert_parse_ok(
         "
       func f () : { x : Nat } = { x = 3 };

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -76,8 +76,6 @@ fn vm_prim_ops() {
 
     assert_("255 +% 1 : Nat8 + 1 + 1 + 1", "3");
     assert_x("255 +% 1 : Nat8 +% 1", &Interruption::AmbiguousOperation); // to do. reconcile with interpreter using more type info.
-
-
 }
 
 #[test]

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -185,6 +185,20 @@ fn vm_records() {
     }
 }
 
+#[ignore]
+#[test]
+fn vm_record_extension() {
+    assert_(
+        "
+      func f () : { x : Nat } = { x = 3 };
+      func g () : { y : Nat } = { y = 3 };
+      let (x, y) = ((), ());
+      { f x and g y with z = 3 };
+    ",
+        "{x = 3; y = 3; z = 3}",
+    )
+}
+
 #[test]
 fn vm_boolean_ops() {
     assert_("false or true", "true");


### PR DESCRIPTION
Now supports full syntax of records and record extension, including cases like this that were problematic in #153 :

- `{ x }`
- `{ x : Nat }`
- `{ x with y = 3 }`
- `{ f x with y = 3 }`
- `{ f x and g y with z = 3 }`
