### PR TITLE
Parser-file polish: Rename `ExpBin` productions, numbering from 0 to 9.

### DIFF
--- a/crates/motoko/src/lib/parser.lalrpop
+++ b/crates/motoko/src/lib/parser.lalrpop
@@ -318,9 +318,9 @@ ExpNonDec0<B>: Exp = {
 ExpNonDec_<B>: Exp_ = Node<ExpNonDec<B>>;
 
 ExpNonDec<B>: Exp = {
-    ExpBin0000<B>,
-    <e1:ExpBin0000_<B>> ":=" <e2:Exp_<Ob>> => Exp::Assign(e1, e2),
-    <e1:ExpBin0000_<B>> <b:BinAssign> <e2:Exp_<Ob>> => Exp::BinAssign(e1, b, e2),
+    ExpBin0<B>,
+    <e1:ExpBin0_<B>> ":=" <e2:Exp_<Ob>> => Exp::Assign(e1, e2),
+    <e1:ExpBin0_<B>> <b:BinAssign> <e2:Exp_<Ob>> => Exp::BinAssign(e1, b, e2),
     "if" <e1:ExpNullary_<Ob>> <e2:ExpNest_> "else" <e3:ExpNest_> => Exp::If(e1, e2, Some(e3)),
     "return" <e:Exp_<B>?> => Exp::Return(e),
     "switch" <e:ExpNullary_<Ob>> "{" <cs:Cases> "}" => Exp::Switch(e, cs),
@@ -465,69 +465,11 @@ BinAssign: BinOp = {
   "#=" => BinOp::Cat,
 }
 
-// Binary operator "level mnemonics." (to do -- renumber/rename.)
-//
-// Prod.
-// Suffix   Operators
-// -------------------------------
-// 0000. %left COLON
-// 000.  %left OR
-// 00.   %left AND
-// .     %nonassoc EQOP NEQOP LEOP LTOP GTOP GEOP
-// 0.    %left ADDOP SUBOP WRAPADDOP WRAPSUBOP HASH
-// 1.    %left MULOP WRAPMULOP DIVOP MODOP
-// 2.    %left OROP
-// 3.    %left ANDOP
-// 4.    %left XOROP
-// 5.    %nonassoc SHLOP SHROP ROTLOP ROTROP
-// 6.    %left POWOP WRAPPOWOP
-//
-
-#[inline]
-ExpBin0000_<B>: Exp_ = Node<ExpBin0000<B>>;
-
-ExpBin0000<B>: Exp = {
-    ExpBin000<B>,
-}
-
-#[inline]
-ExpBin000_<B>: Exp_ = Node<ExpBin000<B>>;
-
-ExpBin000<B>: Exp = {
-    <e1:ExpBin000_<B>> "or" <e2:ExpBin00_<B>> => hrta(Exp::Or(e1, e2)),
-    ExpBin00<B>,
-}
-
-#[inline]
-ExpBin00_<B>: Exp_ = Node<ExpBin00<B>>;
-
-ExpBin00<B>: Exp = {
-    <e1:ExpBin00_<B>> "and" <e2:ExpBin_<B>> => hrta(Exp::And(e1, e2)),
-    ExpBin<B>,
-}
-
-#[inline]
-ExpBin_<B>: Exp_ = Node<ExpBin<B>>;
-
-ExpBin<B>: Exp = {
-    <e1:ExpBin_<B>> "==" <e2:ExpBin0_<B>>  => hrta(Exp::Rel(e1, RelOp::Eq, e2)),
-    <e1:ExpBin_<B>> "!=" <e2:ExpBin0_<B>>  => hrta(Exp::Rel(e1, RelOp::Neq, e2)),
-    <e1:ExpBin_<B>> "<=" <e2:ExpBin0_<B>>  => hrta(Exp::Rel(e1, RelOp::Le, e2)),
-    <e1:ExpBin_<B>> ">=" <e2:ExpBin0_<B>>  => hrta(Exp::Rel(e1, RelOp::Ge, e2)),
-    <e1:ExpBin_<B>> " < " <e2:ExpBin0_<B>> => hrta(Exp::Rel(e1, RelOp::Lt, e2)),
-    <e1:ExpBin_<B>> " > " <e2:ExpBin0_<B>> => hrta(Exp::Rel(e1, RelOp::Gt, e2)),
-    ExpBin0<B>,
-}
-
 #[inline]
 ExpBin0_<B>: Exp_ = Node<ExpBin0<B>>;
 
 ExpBin0<B>: Exp = {
-    <e1:ExpBin0_<B>> "+" <e2:ExpBin1_<B>> => hrta(Exp::Bin(e1, BinOp::Add, e2)),
-    <e1:ExpBin0_<B>> "+%" <e2:ExpBin1_<B>> => hrta(Exp::Bin(e1, BinOp::WAdd, e2)),
-    <e1:ExpBin0_<B>> "-" <e2:ExpBin1_<B>> => hrta(Exp::Bin(e1, BinOp::Sub, e2)),
-    <e1:ExpBin0_<B>> "-%" <e2:ExpBin1_<B>> => hrta(Exp::Bin(e1, BinOp::WSub, e2)),
-    <e1:ExpBin0_<B>> "#" <e2:ExpBin1_<B>> => hrta(Exp::Bin(e1, BinOp::Cat, e2)),
+    <e1:ExpBin0_<B>> "or" <e2:ExpBin1_<B>> => hrta(Exp::Or(e1, e2)),
     ExpBin1<B>,
 }
 
@@ -535,10 +477,7 @@ ExpBin0<B>: Exp = {
 ExpBin1_<B>: Exp_ = Node<ExpBin1<B>>;
 
 ExpBin1<B>: Exp = {
-    <e1:ExpBin1_<B>> "*" <e2:ExpBin2_<B>> => hrta(Exp::Bin(e1, BinOp::Mul, e2)),
-    <e1:ExpBin1_<B>> "*%" <e2:ExpBin2_<B>> => hrta(Exp::Bin(e1, BinOp::WMul, e2)),
-    <e1:ExpBin1_<B>> "/" <e2:ExpBin2_<B>> => hrta(Exp::Bin(e1, BinOp::Div, e2)),
-    <e1:ExpBin1_<B>> "%" <e2:ExpBin2_<B>> => hrta(Exp::Bin(e1, BinOp::Mod, e2)),
+    <e1:ExpBin1_<B>> "and" <e2:ExpBin2_<B>> => hrta(Exp::And(e1, e2)),
     ExpBin2<B>,
 }
 
@@ -546,7 +485,12 @@ ExpBin1<B>: Exp = {
 ExpBin2_<B>: Exp_ = Node<ExpBin2<B>>;
 
 ExpBin2<B>: Exp = {
-    <e1:ExpBin2_<B>> "|" <e2:ExpBin3_<B>> => hrta(Exp::Bin(e1, BinOp::BitOr, e2)),
+    <e1:ExpBin2_<B>> "==" <e2:ExpBin3_<B>>  => hrta(Exp::Rel(e1, RelOp::Eq, e2)),
+    <e1:ExpBin2_<B>> "!=" <e2:ExpBin3_<B>>  => hrta(Exp::Rel(e1, RelOp::Neq, e2)),
+    <e1:ExpBin2_<B>> "<=" <e2:ExpBin3_<B>>  => hrta(Exp::Rel(e1, RelOp::Le, e2)),
+    <e1:ExpBin2_<B>> ">=" <e2:ExpBin3_<B>>  => hrta(Exp::Rel(e1, RelOp::Ge, e2)),
+    <e1:ExpBin2_<B>> " < " <e2:ExpBin3_<B>> => hrta(Exp::Rel(e1, RelOp::Lt, e2)),
+    <e1:ExpBin2_<B>> " > " <e2:ExpBin3_<B>> => hrta(Exp::Rel(e1, RelOp::Gt, e2)),
     ExpBin3<B>,
 }
 
@@ -554,7 +498,11 @@ ExpBin2<B>: Exp = {
 ExpBin3_<B>: Exp_ = Node<ExpBin3<B>>;
 
 ExpBin3<B>: Exp = {
-    <e1:ExpBin3_<B>> "&" <e2:ExpBin4_<B>> => hrta(Exp::Bin(e1, BinOp::BitAnd, e2)),
+    <e1:ExpBin3_<B>> "+" <e2:ExpBin4_<B>> => hrta(Exp::Bin(e1, BinOp::Add, e2)),
+    <e1:ExpBin3_<B>> "+%" <e2:ExpBin4_<B>> => hrta(Exp::Bin(e1, BinOp::WAdd, e2)),
+    <e1:ExpBin3_<B>> "-" <e2:ExpBin4_<B>> => hrta(Exp::Bin(e1, BinOp::Sub, e2)),
+    <e1:ExpBin3_<B>> "-%" <e2:ExpBin4_<B>> => hrta(Exp::Bin(e1, BinOp::WSub, e2)),
+    <e1:ExpBin3_<B>> "#" <e2:ExpBin4_<B>> => hrta(Exp::Bin(e1, BinOp::Cat, e2)),
     ExpBin4<B>,
 }
 
@@ -562,19 +510,18 @@ ExpBin3<B>: Exp = {
 ExpBin4_<B>: Exp_ = Node<ExpBin4<B>>;
 
 ExpBin4<B>: Exp = {
-    <e1:ExpBin4_<B>> "^" <e2:ExpBin5_<B>> => hrta(Exp::Bin(e1, BinOp::Xor, e2)),
+    <e1:ExpBin4_<B>> "*" <e2:ExpBin5_<B>> => hrta(Exp::Bin(e1, BinOp::Mul, e2)),
+    <e1:ExpBin4_<B>> "*%" <e2:ExpBin5_<B>> => hrta(Exp::Bin(e1, BinOp::WMul, e2)),
+    <e1:ExpBin4_<B>> "/" <e2:ExpBin5_<B>> => hrta(Exp::Bin(e1, BinOp::Div, e2)),
+    <e1:ExpBin4_<B>> "%" <e2:ExpBin5_<B>> => hrta(Exp::Bin(e1, BinOp::Mod, e2)),
     ExpBin5<B>,
 }
-
 
 #[inline]
 ExpBin5_<B>: Exp_ = Node<ExpBin5<B>>;
 
 ExpBin5<B>: Exp = {
-    <e1:ExpBin6_<B>> " << " <e2:ExpBin6_<B>> => hrta(Exp::Bin(e1, BinOp::ShL, e2)),
-    <e1:ExpBin6_<B>> " >> " <e2:ExpBin6_<B>> => hrta(Exp::Bin(e1, BinOp::ShR, e2)),
-    <e1:ExpBin6_<B>> "<<>" <e2:ExpBin6_<B>> => hrta(Exp::Bin(e1, BinOp::RotL, e2)),
-    <e1:ExpBin6_<B>> "<>>" <e2:ExpBin6_<B>> => hrta(Exp::Bin(e1, BinOp::RotR, e2)),
+    <e1:ExpBin5_<B>> "|" <e2:ExpBin6_<B>> => hrta(Exp::Bin(e1, BinOp::BitOr, e2)),
     ExpBin6<B>,
 }
 
@@ -582,9 +529,37 @@ ExpBin5<B>: Exp = {
 ExpBin6_<B>: Exp_ = Node<ExpBin6<B>>;
 
 ExpBin6<B>: Exp = {
-    <e1:ExpBin6_<B>> "**" <e2:ExpUn_<B>> => hrta(Exp::Bin(e1, BinOp::Pow, e2)),
-    <e1:ExpBin6_<B>> "**%" <e2:ExpUn_<B>> => hrta(Exp::Bin(e1, BinOp::WPow, e2)),
-    <e1:ExpBin6_<B>> ":" <t:TypeNoBin_> => Exp::Annot(BinAnnotWasHoisted(false), e1, t),
+    <e1:ExpBin6_<B>> "&" <e2:ExpBin7_<B>> => hrta(Exp::Bin(e1, BinOp::BitAnd, e2)),
+    ExpBin7<B>,
+}
+
+#[inline]
+ExpBin7_<B>: Exp_ = Node<ExpBin7<B>>;
+
+ExpBin7<B>: Exp = {
+    <e1:ExpBin7_<B>> "^" <e2:ExpBin8_<B>> => hrta(Exp::Bin(e1, BinOp::Xor, e2)),
+    ExpBin8<B>,
+}
+
+
+#[inline]
+ExpBin8_<B>: Exp_ = Node<ExpBin8<B>>;
+
+ExpBin8<B>: Exp = {
+    <e1:ExpBin9_<B>> " << " <e2:ExpBin9_<B>> => hrta(Exp::Bin(e1, BinOp::ShL, e2)),
+    <e1:ExpBin9_<B>> " >> " <e2:ExpBin9_<B>> => hrta(Exp::Bin(e1, BinOp::ShR, e2)),
+    <e1:ExpBin9_<B>> "<<>" <e2:ExpBin9_<B>> => hrta(Exp::Bin(e1, BinOp::RotL, e2)),
+    <e1:ExpBin9_<B>> "<>>" <e2:ExpBin9_<B>> => hrta(Exp::Bin(e1, BinOp::RotR, e2)),
+    ExpBin9<B>,
+}
+
+#[inline]
+ExpBin9_<B>: Exp_ = Node<ExpBin9<B>>;
+
+ExpBin9<B>: Exp = {
+    <e1:ExpBin9_<B>> "**" <e2:ExpUn_<B>> => hrta(Exp::Bin(e1, BinOp::Pow, e2)),
+    <e1:ExpBin9_<B>> "**%" <e2:ExpUn_<B>> => hrta(Exp::Bin(e1, BinOp::WPow, e2)),
+    <e1:ExpBin9_<B>> ":" <t:TypeNoBin_> => Exp::Annot(BinAnnotWasHoisted(false), e1, t),
     ExpUn<B>,
 }
 


### PR DESCRIPTION
This PR renames those production rules, essentially "adding three" to the numbers that where there, in most cases.

#### Background

We overcome the lack of "precedence" declarations in lalrpop by explicitly demarcating "production levels" where certain operations may be placed relative to others, encoding their precedence with a _system_ of production rules (ten here), instead of one.

The one place where we could not use the conventional multi-production technique to encode Menhir precedence was for `:`, but the workaround was simple.  We parsed `:` as binding tightest of all (to variables, literals, etc.) and then hoisted it above any operator where the `:` appears immediately to the right, as it's immediate right child.  The resulting parse tree is the same as produced with the precedence rules in Menhir.  Thankfully, in lalrpop the resulting code is simple enough, and the parser file only needs to use it for the right children of the production rules in this system, for binary operations.

