### PR TITLE
Fix regex for exponential notation in lexer

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.21"
+version = "0.0.22"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/src/lib/lexer_types.rs
+++ b/crates/motoko/src/lib/lexer_types.rs
@@ -80,8 +80,8 @@ pub enum Token {
     #[regex(r"[0-9]([0-9_]*[0-9]+)?", data!(PrimType::Nat))]
     #[regex(r"0x[0-9a-fA-F]+", data!(PrimType::Nat))] // hexadecimal
     // #[regex(r"[+-][0-9]([0-9_]*[0-9]+)?", data!(PrimType::Int))]
-    #[regex(r"[0-9]([0-9_]*[0-9])?[Ee][0-9]([0-9_]*[0-9])?", data!(PrimType::Float))] // exponential without decimal
-    #[regex(r"[0-9]([0-9_]*[0-9])?\.([0-9]([0-9_]*[0-9])?)?([Ee][0-9]([0-9_]*[0-9])?)?", data!(PrimType::Float))] // exponential with decimal
+    #[regex(r"[0-9]([0-9_]*[0-9])?[Ee]-?[0-9]([0-9_]*[0-9])?", data!(PrimType::Float))] // exponential without decimal
+    #[regex(r"[0-9]([0-9_]*[0-9])?\.([0-9]([0-9_]*[0-9])?)?([Ee]-?[0-9]([0-9_]*[0-9])?)?", data!(PrimType::Float))] // exponential with decimal
     #[regex(r"'(?:[^\\'\s]|\\.)*'|' '", data!(PrimType::Char))]
     #[regex(r#""(?:[^\\"\n]|\\.)*""#, data!(PrimType::Text))]
     Literal((Data, PrimType)),

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.21"
+version = "0.0.22"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 # TODO: set this up as a "workspace dependency"? 
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
-motoko = { path = "../motoko", version = "0.0.21", default-features = false, features = ["parser"] }
+motoko = { path = "../motoko", version = "0.0.22", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"


### PR DESCRIPTION
Fixes cases such as `1.1e-1`, which previously had unexpected behavior in [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko). 