### PR TITLE
Support for `import`s among multiple packages

### DIFF
--- a/crates/motoko/src/lib/package.rs
+++ b/crates/motoko/src/lib/package.rs
@@ -9,7 +9,7 @@ pub fn get_base_library() -> Package {
     // to do -- fix this by making the import semantics understand URIs and package names better.
     let prim_content = include_str!("../packages/prim.mo").to_string();
     base_package.files.insert(
-        "mo:⛔.mo".to_string(),
+        "⛔.mo".to_string(),
         PackageFile {
             content: prim_content,
         },

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -1886,7 +1886,7 @@ fn exp_step<A: Active>(active: &mut A, exp: Exp_) -> Result<Step, Interruption> 
             ));
             Ok(Step {})
         }
-        _ => nyi!(line!()),
+        e => nyi!(line!(), "{:?}", e),
     }
 }
 

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -15,7 +15,8 @@ use crate::{Share, Value};
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyntaxError {
-    pub path: String,
+    pub package_name: Option<String>,
+    pub local_path: String,
     pub code: SyntaxErrorCode,
 }
 
@@ -447,6 +448,7 @@ pub struct Activation {
     #[serde(with = "crate::serde_utils::im_rc_hashmap")]
     pub env: Env,
     pub stack: Stack,
+    pub package: Option<String>,
 }
 
 impl Activation {
@@ -458,6 +460,7 @@ impl Activation {
             cont: Cont::Value_(Value::Unit.share()),
             cont_source: Source::CoreInit, // todo
             cont_prim_type,
+            package: None,
         }
     }
 }
@@ -523,12 +526,16 @@ pub struct Actors {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ModuleFiles {
     #[serde(with = "crate::serde_utils::im_rc_hashmap")]
-    pub map: HashMap<Path, ModuleFileState>,
-    pub import_stack: Vector<Path>,
+    pub map: HashMap<ModulePath, ModuleFileState>,
+    pub import_stack: Vector<ModulePath>,
 }
 
 /// A Path should adhere to certain rules, not enforced by this type.
-pub type Path = String;
+#[derive(Clone, Debug, Serialize, Deserialize, Hash, PartialEq, Eq)]
+pub struct ModulePath {
+    pub package_name: Option<String>,
+    pub local_path: String,
+}
 
 /// The file representation for a module.
 ///
@@ -602,6 +609,7 @@ pub trait Active: ActiveBorrow {
     fn env<'a>(&'a mut self) -> &'a mut Env;
     fn stack<'a>(&'a mut self) -> &'a mut Stack;
     fn store<'a>(&'a mut self) -> &'a mut Store;
+    fn package<'a>(&'a mut self) -> &'a mut Option<String>;
     fn debug_print_out<'a>(&'a mut self) -> &'a mut Vector<DebugPrintLine>;
     fn counts<'a>(&'a mut self) -> &'a mut Counts;
 
@@ -624,13 +632,13 @@ pub trait Active: ActiveBorrow {
 
     fn create_module(
         &mut self,
-        path: String,
+        path: ModulePath,
         id: Option<Id>,
         module: def::Module,
     ) -> Result<Value_, Interruption>;
     fn upgrade_module(
         &mut self,
-        path: String,
+        path: ModulePath,
         id: Option<Id>,
         module: def::Module,
     ) -> Result<Value_, Interruption>;
@@ -720,8 +728,8 @@ pub enum Interruption {
     Breakpoint(Breakpoint),
     Dangling(Pointer),
     NotOwner(Pointer),
-    ImportCycle(Vector<Path>),
-    ModuleFileNotFound(Path),
+    ImportCycle(Vector<ModulePath>),
+    ModuleFileNotFound(ModulePath),
     ModuleNotStatic(Source),
     ModuleFieldNotPublic,
     TypeMismatch(OptionCoreSource),

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -731,7 +731,7 @@ pub enum Interruption {
     ImportCycle(Vector<ModulePath>),
     ModuleFileNotFound(ModulePath),
     ModuleNotStatic(Source),
-    ModuleFieldNotPublic,
+    ModuleFieldNotPublic(Id),
     TypeMismatch(OptionCoreSource),
     NonLiteralInit(Source),
     NoMatchingCase,

--- a/crates/motoko/tests/test_imports.rs
+++ b/crates/motoko/tests/test_imports.rs
@@ -4,7 +4,7 @@ use motoko::ast::ToId;
 use motoko::eval;
 use motoko::shared::Share;
 use motoko::value::ActorId;
-use motoko::vm_types::{Core, Interruption, Limits};
+use motoko::vm_types::{Core, Interruption, Limits, ModulePath};
 use motoko::ToMotoko;
 use test_log::test; // enable logging output for tests by default.
 
@@ -12,7 +12,7 @@ use test_log::test; // enable logging output for tests by default.
 fn import_cycle() {
     let mut core = Core::empty();
 
-    core.set_module("M".to_string(), "import M \"M\"; module { }")
+    core.set_module(None, "M".to_string(), "import M \"M\"; module { }")
         .expect("set_module");
 
     let id = ActorId::Alias("A".to_id());
@@ -23,7 +23,11 @@ fn import_cycle() {
         "import M \"M\"; actor { }",
     );
 
-    let stack = vector!["M".to_string(), "M".to_string()];
+    let path = ModulePath {
+        package_name: None,
+        local_path: "M".to_string(),
+    };
+    let stack = vector![path.clone(), path.clone()];
     assert_eq!(r, Err(Interruption::ImportCycle(stack)))
 }
 
@@ -32,12 +36,13 @@ fn import_dag_size2() {
     let mut core = Core::empty();
 
     core.set_module(
+        None,
         "M".to_string(),
         "import N \"N\"; module { public func f () { N.f() } }",
     )
     .expect("set_module M");
 
-    core.set_module("N".to_string(), "module { public func f () { #ok } }")
+    core.set_module(None, "N".to_string(), "module { public func f () { #ok } }")
         .expect("set_module N");
 
     let id = ActorId::Alias("A".to_id());
@@ -46,6 +51,37 @@ fn import_dag_size2() {
         format!("{}:{}", file!(), line!()),
         id.clone(),
         "import M \"M\"; actor { public func f () { M.f() } }",
+    )
+    .expect("set_actor");
+
+    assert_eq!(
+        core.call(
+            &id,
+            &"f".to_id(),
+            ().to_motoko().unwrap().share(),
+            &Limits::none()
+        ),
+        eval("#ok")
+    );
+}
+
+#[test]
+fn import_package_module() {
+    let mut core = Core::empty();
+
+    core.set_module(
+        Some("p".to_string()),
+        "M".to_string(),
+        "module { public func f () { #ok } }",
+    )
+    .expect("set_module");
+
+    let id = ActorId::Alias("A".to_id());
+
+    core.set_actor(
+        format!("{}:{}", file!(), line!()),
+        id.clone(),
+        "import M \"mo:p/M\"; actor { public func f () { M.f() } }",
     )
     .expect("set_actor");
 

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -11,7 +11,7 @@ fn assert_parse_packages(package: Package) {
         package.name,
         package.files.len()
     );
-    assert!(!package.files.is_empty());
+    //assert!(!package.files.is_empty());
     let mut files = package.files.into_iter().collect::<Vec<_>>();
     files.sort_by_cached_key(|(path, _)| path.clone());
     let total = files.len();
@@ -39,37 +39,56 @@ fn assert_parse_packages(package: Package) {
 fn assert_eval_packages(main_package: Package, dependencies: Vec<Package>) {
     println!("Evaluating package: {}", main_package.name);
     let packages = vec![vec![main_package], dependencies].concat();
-    assert!(packages.iter().all(|p| !p.files.is_empty()));
+    //assert!(!packages.iter().all(|p| !p.files.is_empty()));
     let mut core = Core::empty();
     let mut files = packages
         .into_iter()
-        .flat_map(|p| p.files)
+        .flat_map(|p| {
+            let package_name = p.name.clone();
+            p.files
+                .into_iter()
+                .map(move |(path, file)| (package_name.clone(), path, file))
+        })
         .collect::<Vec<_>>();
-    files.sort_by_cached_key(|(path, _)| path.clone());
+    files.sort_by_cached_key(|(package_name, path, _)| (package_name.clone(), path.clone()));
     let total = files.len();
+    let mut total_loaded = 0;
     let mut parse_count = 0;
     let mut error_count = 0;
     println!(
         "Attempting to load {} modules via set_module (parsing only; is order-independent).",
         total
     );
-    for (path, file) in files.iter() {
+    for (package_name, path, file) in files.iter() {
         parse_count += 1;
         // drop .mo from the path (will not be there for the imports)
         let path = format!("{}", &path[0..path.len() - 3]);
-        match core.set_module(path.clone(), &file.content) {
-            Ok(_) => println!(" set_module {}. ✅ {}", parse_count, path),
-            Err(i) => {
-                error_count += 1;
-                println!(" set_module {}. ❌ {} : {:?}", parse_count, path, i)
+        if Core::is_module_def(&file.content) {
+            match core.set_module(Some(package_name.to_string()), path.clone(), &file.content) {
+                Ok(_) => {
+                    total_loaded += 1;
+                    println!(" set_module {}. ✅ {}/{}", parse_count, package_name, path)
+                }
+                Err(i) => {
+                    error_count += 1;
+                    println!(
+                        " set_module {}. ❌ {}/{} : {:?}",
+                        parse_count, package_name, path, i
+                    )
+                }
             }
+        } else {
+            println!(
+                " skipping non-module {}. ✅ {}/{}",
+                parse_count, package_name, path
+            )
         }
     }
-    println!("Attempted to load {} modules.", total);
+    println!("Attempted to parse {} files", total);
     if error_count > 0 {
         println!("  But, found {} set_module/eval errors.", error_count);
     } else {
-        println!("  Success!");
+        println!("  Success!\n  Loaded all {} modules.", total_loaded);
     }
     println!(
         "Attempting to evaluate {} modules (process all imports and definitions).",
@@ -77,14 +96,20 @@ fn assert_eval_packages(main_package: Package, dependencies: Vec<Package>) {
     );
     let mut eval_count = 0;
     let mut error_count = 0;
-    for (path, file) in files {
+    for (package_name, path, file) in files {
         eval_count += 1;
         let mut core2 = core.clone();
+        core2
+            .set_ambient_package_name(Some(package_name.clone()))
+            .expect("");
         match core2.eval(&file.content) {
-            Ok(_) => println!(" eval {}. ✅ {}", eval_count, path),
+            Ok(_) => println!(" eval {}. ✅ {}/{}", eval_count, package_name, path),
             Err(i) => {
                 error_count += 1;
-                println!(" eval {}. ❌ {} : {:?}", eval_count, path, i)
+                println!(
+                    " eval {}. ❌ {}/{} : {:?}",
+                    eval_count, package_name, path, i
+                )
             }
         }
     }
@@ -112,7 +137,6 @@ fn parse_base_library_tests() {
     assert_parse_packages(get_base_library_tests())
 }
 
-#[ignore]
 #[test]
 fn eval_prim_library() {
     assert_eval_packages(get_prim_library(), vec![]);
@@ -123,7 +147,6 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
-#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(get_base_library_tests(), vec![get_base_library()]);

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -147,6 +147,7 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
+#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(get_base_library_tests(), vec![get_base_library()]);

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -5,6 +5,66 @@ use motoko::{
 
 use test_log::test;
 
+#[test]
+fn import_all_your_base() {
+    let import_all = r##"
+ import Array "mo:base/Array";
+ import AssocList "mo:base/AssocList";
+ import Blob "mo:base/Blob";
+ import Bool "mo:base/Bool";
+ import Buffer "mo:base/Buffer";
+ import CertifiedData "mo:base/CertifiedData";
+ import Char "mo:base/Char";
+ import Debug "mo:base/Debug";
+ import Deque "mo:base/Deque";
+ import Error "mo:base/Error";
+ import ExperimentalCycles "mo:base/ExperimentalCycles";
+ import ExperimentalInternetComputer "mo:base/ExperimentalInternetComputer";
+ import ExperimentalStableMemory "mo:base/ExperimentalStableMemory";
+ import Float "mo:base/Float";
+ import Func "mo:base/Func";
+ import Hash "mo:base/Hash";
+ import HashMap "mo:base/HashMap";
+ import Heap "mo:base/Heap";
+ import Int "mo:base/Int";
+ import Int16 "mo:base/Int16";
+ import Int32 "mo:base/Int32";
+ import Int64 "mo:base/Int64";
+ import Int8 "mo:base/Int8";
+ import Iter "mo:base/Iter";
+ import IterType "mo:base/IterType";
+ import List "mo:base/List";
+ import Nat "mo:base/Nat";
+ import Nat16 "mo:base/Nat16";
+ import Nat32 "mo:base/Nat32";
+ import Nat64 "mo:base/Nat64";
+ import Nat8 "mo:base/Nat8";
+ import None "mo:base/None";
+ import Option "mo:base/Option";
+ import Order "mo:base/Order";
+ import Prelude "mo:base/Prelude";
+ import Principal "mo:base/Principal";
+ import RBTree "mo:base/RBTree";
+ import Stack "mo:base/Stack";
+ import Random "mo:base/Random";
+ import Text "mo:base/Text";
+ import Time "mo:base/Time";
+ import Trie "mo:base/Trie";
+ import TrieMap "mo:base/TrieMap";
+ import TrieSet "mo:base/TrieSet";
+   "##;
+
+    let mut core = Core::empty();
+    let base = get_base_library();
+    for (path, file) in base.files.into_iter() {
+        // remove '.mo' from suffix of the filename to produce the path
+        let path = format!("{}", &path[0..path.len() - 3]);
+        core.set_module(Some("base".to_string()), path.clone(), &file.content)
+            .expect("load base");
+    }
+    core.eval(&import_all).expect("eval import all");
+}
+
 fn assert_parse_packages(package: Package) {
     println!(
         "Parsing package: {}, with {} files.",


### PR DESCRIPTION
This PR completes the initial work for importing base library modules.  

Replaces #162 and extends #158 so that we are closer to running unit tests.

Now, each base library unit test can import base module(s) that it needs.

This permits us to begin to _run_ these unit tests, at last.  Details beyond the scope of the PR were exposed, below.

-------------

Evaluating the `base` unit tests now each expose an open issue in the VM (with repeats):
 - `let`-style module declarations need to respect `public` qualifiers.  They seem to be ignored, resulting in projection errors.
 - The `matchers` package is needed for some tests, but we don't have it loaded or in the repo at the moment.
 - More robust pattern-matching cases for declarations (exposed by `trieTest.mo`)

Subsequent PRs will address these issues.