### PR TITLE
Fix: Declare variables with type annotations.

### DIFF
--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -35,7 +35,7 @@ macro_rules! type_mismatch_ {
     };
     ($file:expr, $line:expr, $name:expr) => {
         Interruption::TypeMismatch($crate::vm_types::OptionCoreSource(Some(CoreSource {
-            name: Some($name),
+            name: Some($name.to_string()),
             description: None,
             file: $file.to_string(),
             line: $line,
@@ -43,8 +43,8 @@ macro_rules! type_mismatch_ {
     };
     ($file:expr, $line:expr, $name:expr, $description:expr) => {
         Interruption::TypeMismatch($crate::vm_types::OptionCoreSource(Some(CoreSource {
-            name: Some($name),
-            description: Some($description),
+            name: Some($name.to_string()),
+            description: Some($description.to_string()),
             file: $file.to_string(),
             line: $line,
         })))

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -207,7 +207,6 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
-#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(get_base_library_tests(), vec![get_base_library()]);

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -207,6 +207,7 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
+#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(get_base_library_tests(), vec![get_base_library()]);

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -86,6 +86,8 @@ fn vm_vars() {
     assert_("var x = 1; x", "1");
     assert_("var x = 1; x := 2; x", "2");
     assert_x("1 := 1", &type_mismatch_!());
+    assert_("var x : Nat = 1", "()");
+    assert_("var (x : Nat) = 1", "()");
 }
 
 #[test]


### PR DESCRIPTION
The `Trie` module used a form of variable declaration that we didn't support.  This PR addresses that.

It also polishes a `TypeMismatch` message in a way that we could repeat elsewhere, which helps in exposing the next issue.

Now, the next issue on for `TrieExampleTest.mo` is supporting the "magic" `.chars` field for `Text` values.  Another PR.