### PR TITLE
Expose implicitly-public members of special ⛔ package.

### DIFF
--- a/crates/motoko/src/lib/ast.rs
+++ b/crates/motoko/src/lib/ast.rs
@@ -68,6 +68,7 @@ pub enum Source {
     CoreUpgradeActor,
     CoreSetModule,
     CoreCall,
+    ImportPrim,
 }
 
 impl Source {
@@ -122,6 +123,7 @@ impl std::fmt::Display for Source {
             Source::CoreUpgradeActor => write!(f, "(Core.upgrade_actor())"),
             Source::CoreCall => write!(f, "(Core.call())"),
             Source::CoreSetModule => write!(f, "(Core.set_module())"),
+            Source::ImportPrim => write!(f, "(import ⛔)"),
         }
     }
 }

--- a/crates/motoko/src/lib/package.rs
+++ b/crates/motoko/src/lib/package.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub fn get_base_library() -> Package {
     let mut base_package: Package =
         serde_json::from_str(include_str!("../packages/base.json")).unwrap();
+/*
     // to do -- fix this by making the import semantics understand URIs and package names better.
     let prim_content = include_str!("../packages/prim.mo").to_string();
     base_package.files.insert(
@@ -14,6 +15,7 @@ pub fn get_base_library() -> Package {
             content: prim_content,
         },
     );
+*/
     base_package
 }
 

--- a/crates/motoko/src/lib/package.rs
+++ b/crates/motoko/src/lib/package.rs
@@ -6,16 +6,16 @@ use serde::{Deserialize, Serialize};
 pub fn get_base_library() -> Package {
     let mut base_package: Package =
         serde_json::from_str(include_str!("../packages/base.json")).unwrap();
-/*
-    // to do -- fix this by making the import semantics understand URIs and package names better.
-    let prim_content = include_str!("../packages/prim.mo").to_string();
-    base_package.files.insert(
-        "⛔.mo".to_string(),
-        PackageFile {
-            content: prim_content,
-        },
-    );
-*/
+    /*
+        // to do -- fix this by making the import semantics understand URIs and package names better.
+        let prim_content = include_str!("../packages/prim.mo").to_string();
+        base_package.files.insert(
+            "⛔.mo".to_string(),
+            PackageFile {
+                content: prim_content,
+            },
+        );
+    */
     base_package
 }
 

--- a/crates/motoko/src/lib/value.rs
+++ b/crates/motoko/src/lib/value.rs
@@ -282,7 +282,7 @@ impl PrimFunction {
         use CollectionFunction::*;
         use PrimFunction::*;
         Ok(match name.as_str() {
-            "\"debugPrint\"" => DebugPrint,
+            "\"print\"" => DebugPrint,
             "\"natToText\"" => NatToText,
             "\"hashMapNew\"" => Collection(HashMap(HashMapFunction::New)),
             "\"hashMapPut\"" => Collection(HashMap(HashMapFunction::Put)),

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -674,7 +674,27 @@ mod def {
                         };
                         def::insert_static_field(active, &df.dec.1, &df)?;
                     }
-                    let fields = init.fields.clone(); // -- to do, if the package_name is ⛔, then "promote" everything to be public.
+                    let do_promote_fields_to_public_vis =
+                        // if the package_name is ⛔, then "promote" everything to be public.
+                        active.package().as_ref().map_or(false, |n| n.as_str() == "⛔");
+                    let fields = // promote.
+                        if do_promote_fields_to_public_vis {
+                            crate::ast::Delim{
+                                vec:
+                                init.fields.vec.iter().map(
+                                    |f|
+                                    crate::ast::NodeData(
+                                        DecField{
+                                            vis:Some(
+                                                crate::ast::NodeData(crate::ast::Vis::Public(None),
+                                                                     crate::ast::Source::ImportPrim).share()),
+                                            .. f.0.clone()},
+                                        f.1.clone()).share()).collect(),
+                                    .. init.fields.clone()
+                            }
+                        } else {
+                            init.fields.clone()
+                        };
                     let v = def::module(
                         active,
                         path.clone(),

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -628,8 +628,8 @@ mod def {
         if let Pat::Var(x) = p.0.clone() {
             let path = format!("{}", &path[1..path.len() - 1]);
             let (package_name, local_path) = if path == "mo:⛔" {
-                // prim module special case where "base" is implied.
-                (Some("base".to_string()), "⛔".to_string())
+                // to do -- generalize the support for package names used without local paths
+                (Some("⛔".to_string()), "lib".to_string())
             } else if path.starts_with("mo:") {
                 let path = format!("{}", &path[3..path.len()]);
                 let mut sep_parts = path.split("/");

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -674,6 +674,7 @@ mod def {
                         };
                         def::insert_static_field(active, &df.dec.1, &df)?;
                     }
+                    let fields = init.fields.clone(); // -- to do, if the package_name is ⛔, then "promote" everything to be public.
                     let v = def::module(
                         active,
                         path.clone(),
@@ -681,7 +682,7 @@ mod def {
                         Source::CoreSetModule,
                         None,
                         None,
-                        &init.fields,
+                        &fields,
                         None,
                     )?;
                     active.defs().leave_context(saved, &ctxid);

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -5,6 +5,39 @@ use motoko::{
 
 use test_log::test;
 
+fn new_core_with_base() -> Core {
+    let mut core = Core::empty();
+
+    let prim = get_prim_library();
+    for (path, file) in prim.files.into_iter() {
+        // remove '.mo' from suffix of the filename to produce the path
+        let path = format!("{}", &path[0..path.len() - 3]);
+        core.set_module(Some("⛔".to_string()), path.clone(), &file.content)
+            .expect("load prim");
+    }
+
+    let base = get_base_library();
+    for (path, file) in base.files.into_iter() {
+        // remove '.mo' from suffix of the filename to produce the path
+        let path = format!("{}", &path[0..path.len() - 3]);
+        core.set_module(Some("base".to_string()), path.clone(), &file.content)
+            .expect("load base");
+    }
+
+    core
+}
+
+#[test]
+fn import_and_eval_debug_print() {
+    let print_hello_world = r##"
+ import Debug "mo:base/Debug";
+ Debug.print "hello world"
+ "##;
+    let mut core = new_core_with_base();
+    core.eval(&print_hello_world)
+        .expect("eval print hello world");
+}
+
 #[test]
 fn import_all_your_base() {
     let import_all = r##"
@@ -54,14 +87,7 @@ fn import_all_your_base() {
  import TrieSet "mo:base/TrieSet";
    "##;
 
-    let mut core = Core::empty();
-    let base = get_base_library();
-    for (path, file) in base.files.into_iter() {
-        // remove '.mo' from suffix of the filename to produce the path
-        let path = format!("{}", &path[0..path.len() - 3]);
-        core.set_module(Some("base".to_string()), path.clone(), &file.content)
-            .expect("load base");
-    }
+    let mut core = new_core_with_base();
     core.eval(&import_all).expect("eval import all");
 }
 
@@ -207,6 +233,7 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
+#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -207,8 +207,7 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
-#[ignore]
 #[test]
 fn eval_base_library_tests() {
-    assert_eval_packages(get_base_library_tests(), vec![get_base_library()]);
+    assert_eval_packages(get_base_library_tests(), vec![get_base_library(), get_prim_library()]);
 }

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -209,5 +209,8 @@ fn eval_base_library() {
 
 #[test]
 fn eval_base_library_tests() {
-    assert_eval_packages(get_base_library_tests(), vec![get_base_library(), get_prim_library()]);
+    assert_eval_packages(
+        get_base_library_tests(),
+        vec![get_base_library(), get_prim_library()],
+    );
 }

--- a/crates/motoko/tests/test_vm.rs
+++ b/crates/motoko/tests/test_vm.rs
@@ -278,9 +278,9 @@ fn for_() {
 
 #[test]
 fn prim_debug_print() {
-    assert_("prim \"debugPrint\" \"hello, world\"", "()");
+    assert_("prim \"print\" \"hello, world\"", "()");
     assert_(
-        "let Debug = { print = prim \"debugPrint\" }; Debug.print \"hello, world\"",
+        "let Debug = { print = prim \"print\" }; Debug.print \"hello, world\"",
         "()",
     );
 }
@@ -384,17 +384,17 @@ fn function_call_return_restores_env() {
 fn demo_redex_stepping() {
     let prog = r#"
 let a = 1;
-(prim "debugPrint") "Hello, VM 1!";
-(prim "debugPrint") "Hello, VM 2!";
-(prim "debugPrint") "Hello, VM 3!";
-(prim "debugPrint") "Hello, VM 4!";
+(prim "print") "Hello, VM 1!";
+(prim "print") "Hello, VM 2!";
+(prim "print") "Hello, VM 3!";
+(prim "print") "Hello, VM 4!";
 var y = 666;
-(prim "debugPrint") "Hello, VM 5!";
-(prim "debugPrint") "Hello, VM 6!";
-(prim "debugPrint") "Hello, VM 7!";
+(prim "print") "Hello, VM 5!";
+(prim "print") "Hello, VM 6!";
+(prim "print") "Hello, VM 7!";
 var x = y + a;
-(prim "debugPrint") "Hello, VM 8!";
-(prim "debugPrint") "Hello, VM 9!";
+(prim "print") "Hello, VM 8!";
+(prim "print") "Hello, VM 9!";
 x + 1;
 "#;
     assert_(prog, "668");
@@ -420,7 +420,7 @@ f()
 #[test]
 fn demo_for_() {
     let prog = r#"
-let Debug = { print = prim "debugPrint"};
+let Debug = { print = prim "print"};
 var x = 0;
 let Iter = { range = func(end){
   { next = func() {


### PR DESCRIPTION
This PR exposes the implicitly-public members of special ⛔ package.

(Before, we couldn't use anything from ⛔, as it was all viewed as "private" to the VM's logic.)

Changes:
- cleanup earlier hack -- `mo:⛔` implies `⛔/lib.mo` (not `base/⛔.mo` as the hack had done).
- fix the name of `"debugPrint"` primitive to be called `"print"`, as in `⛔/lib.mo`
- Unit test confirms that we can print from `Debug.print` now, going through both `base` and `⛔` packages to get the primitive definition of `prim "print"` from the latter.