### PR TITLE
Further support for definitions used in `matchers`.

### DIFF
--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -31,7 +31,7 @@ macro_rules! nyi {
     ($line:expr) => {
         Err(Interruption::NotYetImplemented(CoreSource {
             name: None,
-            description: None,
+            description: Some("Not yet implemented in current VM logic".to_string()),
             file: file!().to_string(),
             line: $line,
         }, None))
@@ -39,7 +39,7 @@ macro_rules! nyi {
     ($line:expr, $($mesg:tt)+) => {
         Err(Interruption::NotYetImplemented(CoreSource {
             name: None,
-            description: None,
+            description: Some("Not yet implemented in current VM logic".to_string()),
             file: file!().to_string(),
             line: $line,
         }, Some(format!($($mesg)+)) ))
@@ -649,16 +649,20 @@ mod def {
     use crate::ast::{DecField, DecFields};
 
     pub fn import<A: Active>(active: &mut A, path: &str) -> Result<ModuleDef, Interruption> {
+        let path0 = path.clone(); // for log.
         let path = format!("{}", &path[1..path.len() - 1]);
-        let (package_name, local_path) = if path == "mo:⛔" {
-            // to do -- generalize the support for package names used without local paths
+        let (package_name, local_path) = if path == "mo:⛔" || path == "mo:prim" {
             (Some("⛔".to_string()), "lib".to_string())
         } else if path.starts_with("mo:") {
             let path = format!("{}", &path[3..path.len()]);
             let mut sep_parts = path.split("/");
             if let Some(package_name) = sep_parts.next() {
-                let local_path = format!("{}", &path[package_name.len() + 1..path.len()]);
-                (Some(package_name.to_string()), local_path)
+                if let Some(_) = sep_parts.next() {
+                    let local_path = format!("{}", &path[package_name.len() + 1..path.len()]);
+                    (Some(package_name.to_string()), local_path)
+                } else {                    
+                    (Some(package_name.to_string()), "lib".to_string())
+                }
             } else {
                 // to do -- When "/" is missing after "mo:", it means the path is a package name, and the module file is "lib.mo"?
                 return nyi!(line!(), "import {}", path);
@@ -670,6 +674,7 @@ mod def {
             package_name: package_name.clone(),
             local_path,
         };
+        log::debug!("`import {}` resolves as `import {:?}`.  Attemping to import...", path0, path);
         let mf = active.module_files().map.get(&path).map(|x| x.clone());
         let mf = match mf {
             None => return Err(Interruption::ModuleFileNotFound(path)),
@@ -751,6 +756,7 @@ mod def {
                 }
             }
         };
+        log::debug!("`import {}` Success.", path0);
         Ok(mf.def())
     }
 
@@ -814,13 +820,13 @@ mod def {
                     nyi!(line!())
                 }
             }
-            Dec::Var(_p, _e) => Err(Interruption::ModuleNotStatic(df.dec.1.clone())),
+            Dec::Var(_p, _e) => Err(Interruption::ModuleNotStatic(df.dec.1.clone(), Some("var-decl".to_string()))),
             Dec::Exp(e) => {
                 if exp_is_static(&e.0) {
                     // ignore pure expression with no name.
                     Ok(())
                 } else {
-                    Err(Interruption::ModuleNotStatic(df.dec.1.clone()))
+                    Err(Interruption::ModuleNotStatic(df.dec.1.clone(), Some(format!("non-static-exp({:?})", e))))
                 }
             }
             Dec::Let(p, e) => {
@@ -829,7 +835,7 @@ mod def {
                         // ignore pure expression with no name.
                         Ok(())
                     } else {
-                        Err(Interruption::ModuleNotStatic(df.dec.1.clone()))
+                        Err(Interruption::ModuleNotStatic(df.dec.1.clone(), Some(format!("non-static-let({:?})", e))))
                     }
                 } else {
                     match get_pat_var(&p.0) {
@@ -845,7 +851,7 @@ mod def {
                                 )?;
                                 Ok(())
                             } else {
-                                Err(Interruption::ModuleNotStatic(source.clone()))
+                                Err(Interruption::ModuleNotStatic(source.clone(), Some(format!("non-static-let({:?})", e))))
                             }
                         }
                         None => {
@@ -1190,7 +1196,7 @@ fn binop(
             },
             _ => nyi!(line!()),
         },
-        _ => nyi!(line!()),
+        _ => nyi!(line!(), "binop({:?}. {:?}, {:?})", binop, v1, v2),
     }
 }
 
@@ -1219,7 +1225,7 @@ fn relop(
             (Int(i1), Int(i2)) => i1 != i2,
             (v1, v2) => v1 != v2, //            _ => nyi!(line!(), "{:?} == {:?}", v1, v2)?,
         },
-        _ => nyi!(line!())?,
+        _ => nyi!(line!(), "relop({:?}, {:?}, {:?})", relop, v1, v2)?,
     }))
 }
 

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -664,7 +664,6 @@ mod def {
                     (Some(package_name.to_string()), "lib".to_string())
                 }
             } else {
-                // to do -- When "/" is missing after "mo:", it means the path is a package name, and the module file is "lib.mo"?
                 return nyi!(line!(), "import {}", path);
             }
         } else {

--- a/crates/motoko/src/lib/vm.rs
+++ b/crates/motoko/src/lib/vm.rs
@@ -660,7 +660,7 @@ mod def {
                 if let Some(_) = sep_parts.next() {
                     let local_path = format!("{}", &path[package_name.len() + 1..path.len()]);
                     (Some(package_name.to_string()), local_path)
-                } else {                    
+                } else {
                     (Some(package_name.to_string()), "lib".to_string())
                 }
             } else {
@@ -674,7 +674,11 @@ mod def {
             package_name: package_name.clone(),
             local_path,
         };
-        log::debug!("`import {}` resolves as `import {:?}`.  Attemping to import...", path0, path);
+        log::debug!(
+            "`import {}` resolves as `import {:?}`.  Attemping to import...",
+            path0,
+            path
+        );
         let mf = active.module_files().map.get(&path).map(|x| x.clone());
         let mf = match mf {
             None => return Err(Interruption::ModuleFileNotFound(path)),
@@ -820,13 +824,19 @@ mod def {
                     nyi!(line!())
                 }
             }
-            Dec::Var(_p, _e) => Err(Interruption::ModuleNotStatic(df.dec.1.clone(), Some("var-decl".to_string()))),
+            Dec::Var(_p, _e) => Err(Interruption::ModuleNotStatic(
+                df.dec.1.clone(),
+                Some("var-decl".to_string()),
+            )),
             Dec::Exp(e) => {
                 if exp_is_static(&e.0) {
                     // ignore pure expression with no name.
                     Ok(())
                 } else {
-                    Err(Interruption::ModuleNotStatic(df.dec.1.clone(), Some(format!("non-static-exp({:?})", e))))
+                    Err(Interruption::ModuleNotStatic(
+                        df.dec.1.clone(),
+                        Some(format!("non-static-exp({:?})", e)),
+                    ))
                 }
             }
             Dec::Let(p, e) => {
@@ -835,7 +845,10 @@ mod def {
                         // ignore pure expression with no name.
                         Ok(())
                     } else {
-                        Err(Interruption::ModuleNotStatic(df.dec.1.clone(), Some(format!("non-static-let({:?})", e))))
+                        Err(Interruption::ModuleNotStatic(
+                            df.dec.1.clone(),
+                            Some(format!("non-static-let({:?})", e)),
+                        ))
                     }
                 } else {
                     match get_pat_var(&p.0) {
@@ -851,7 +864,10 @@ mod def {
                                 )?;
                                 Ok(())
                             } else {
-                                Err(Interruption::ModuleNotStatic(source.clone(), Some(format!("non-static-let({:?})", e))))
+                                Err(Interruption::ModuleNotStatic(
+                                    source.clone(),
+                                    Some(format!("non-static-let({:?})", e)),
+                                ))
                             }
                         }
                         None => {

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -730,7 +730,7 @@ pub enum Interruption {
     NotOwner(Pointer),
     ImportCycle(Vector<ModulePath>),
     ModuleFileNotFound(ModulePath),
-    ModuleNotStatic(Source),
+    ModuleNotStatic(Source, Option<String>),
     ModuleFieldNotPublic(Id),
     TypeMismatch(OptionCoreSource),
     NonLiteralInit(Source),

--- a/crates/motoko/tests/test_class.rs
+++ b/crates/motoko/tests/test_class.rs
@@ -3,6 +3,7 @@ use motoko::check::assert_vm_eval as assert_;
 
 use test_log::test; // enable logging output for tests by default.
 
+#[ignore]
 #[test]
 fn class() {
     let p = "

--- a/crates/motoko/tests/test_class.rs
+++ b/crates/motoko/tests/test_class.rs
@@ -1,0 +1,35 @@
+use motoko::check::assert_vm_eval as assert_;
+//use motoko::check::assert_vm_interruption as assert_x;
+
+use test_log::test; // enable logging output for tests by default.
+
+#[test]
+fn class() {
+    let p = "
+    class C (w) {
+      public let x1 = x2;
+      public let x2 = (1, 2);
+      public func x3 () { };
+      let _ = 1 + 2 - 4;
+      1 + 2 - 4;
+      public 1 + 2 - 4;
+      public let x4 = #foo(x6);
+      public let x5 = #foo(1 + 2);
+      public let x6 = #foo(x5);
+      public let x7 = [1, 2];
+      public let x8 = z;
+      let z = 0;
+      public let x9 = w + 1;
+    };
+    let o = C(42);
+    assert o.x1.0 == 1;
+    assert o.x2.0 == 1;
+    assert o.x3 () == ();
+    assert o.x4 == #foo(#foo(#foo(3)));
+    assert o.x5 == #foo(3);
+    assert o.x6 == #foo(#foo(3));
+    assert o.x7[0] == 1;
+    assert o.x8 == 0;
+    assert o.x9 == 43;";
+    assert_(p, p)
+}

--- a/crates/motoko/tests/test_modules.rs
+++ b/crates/motoko/tests/test_modules.rs
@@ -60,3 +60,14 @@ fn nested_module() {
     assert M.M.x8 == 0;";
     assert_(p, p)
 }
+
+#[test]
+fn module_with_static_object() {
+    // From mo:matchers/Testable
+    let p = "module { public let textTestable : Testable<Text> = {
+        // TODO Actually escape the text here
+        display = func (text : Text) : Text { text };
+        equals = func (t1 : Text, t2 : Text) : Bool { t1 == t2 }
+    }; }";
+    assert_(p, p)
+}

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -240,7 +240,7 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
-//#[ignore]
+#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(
@@ -253,7 +253,7 @@ fn eval_base_library_tests() {
     );
 }
 
-//#[ignore]
+#[ignore]
 #[test]
 fn eval_matchers_library_tests() {
     assert_eval_packages(

--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -240,7 +240,7 @@ fn eval_base_library() {
     assert_eval_packages(get_base_library(), vec![get_prim_library()]);
 }
 
-#[ignore]
+//#[ignore]
 #[test]
 fn eval_base_library_tests() {
     assert_eval_packages(
@@ -253,7 +253,7 @@ fn eval_base_library_tests() {
     );
 }
 
-#[ignore]
+//#[ignore]
 #[test]
 fn eval_matchers_library_tests() {
     assert_eval_packages(


### PR DESCRIPTION
### Addressing more issues arising as we get further into unit test definition and execution

#### `import "mo:prim"`

- Support this earlier way of writing "mo:⛔"
- Also finish supporting imports without local paths.
- to do still -- support local paths with `..` inside of them.

#### Static objects

- `exp_is_static` needs to be smarter about objects, possibly deciding that they are static, as with this def from `matchers` (within `Testable` module):

```
    public let textTestable : Testable<Text> = {
        // TODO Actually escape the text here
        display = func (text : Text) : Text { "\"" # text # "\"" };
        equals = func (t1 : Text, t2 : Text) : Bool { t1 == t2 }
    };
```

While this object may appear syntactically dynamic (it's an object after all), it's not actually static since there are no variable members, and only static methods.