### PR TITLE
Feature: `Core::new_with_base`

### DIFF
--- a/crates/motoko/tests/test_packages.rs
+++ b/crates/motoko/tests/test_packages.rs
@@ -7,35 +7,13 @@ use motoko::{
 
 use test_log::test;
 
-fn new_core_with_base() -> Core {
-    let mut core = Core::empty();
-
-    let prim = get_prim_library();
-    for (path, file) in prim.files.into_iter() {
-        // remove '.mo' from suffix of the filename to produce the path
-        let path = format!("{}", &path[0..path.len() - 3]);
-        core.set_module(Some("⛔".to_string()), path.clone(), &file.content)
-            .expect("load prim");
-    }
-
-    let base = get_base_library();
-    for (path, file) in base.files.into_iter() {
-        // remove '.mo' from suffix of the filename to produce the path
-        let path = format!("{}", &path[0..path.len() - 3]);
-        core.set_module(Some("base".to_string()), path.clone(), &file.content)
-            .expect("load base");
-    }
-
-    core
-}
-
 #[test]
 fn import_and_eval_debug_print() {
     let print_hello_world = r##"
  import Debug "mo:base/Debug";
  Debug.print "hello world"
  "##;
-    let mut core = new_core_with_base();
+    let mut core = Core::new_with_base();
     core.eval(&print_hello_world)
         .expect("eval print hello world");
 }
@@ -89,7 +67,7 @@ fn import_all_your_base() {
  import TrieSet "mo:base/TrieSet";
    "##;
 
-    let mut core = new_core_with_base();
+    let mut core = Core::new_with_base();
     core.eval(&import_all).expect("eval import all");
 }
 


### PR DESCRIPTION
`Core` constructor that produces an empty core loaded with `base` modules and compiler-base primitives.

(This encapsulates an idiom that we use in our larger tests now, for use in `mo-vm` UI code, and elsewhere.)