### PR TITLE
Fix comment detection after double quote in single quotes

### DIFF
--- a/crates/motoko/src/lib/lexer.rs
+++ b/crates/motoko/src/lib/lexer.rs
@@ -185,17 +185,17 @@ pub fn find_comment_spans(input: &str) -> Vec<Span> {
     let mut nest_depth = 0;
     while let Some((i, c)) = iter.next() {
         match c {
-            '"' if nest_depth == 0 => {
+            '"' | '\'' if nest_depth == 0 => {
                 // String literal
                 let mut escaped = false;
-                while let Some((_, c)) = iter.next() {
+                while let Some((_, c1)) = iter.next() {
                     if escaped {
                         // Skip escaped character
                         escaped = false;
-                    } else if c == '\\' {
+                    } else if c1 == '\\' {
                         // Escape next character
                         escaped = true;
-                    } else if c == '"' {
+                    } else if c1 == c {
                         // End string literal
                         break;
                     }

--- a/crates/motoko/tests/test_parser.rs
+++ b/crates/motoko/tests/test_parser.rs
@@ -454,3 +454,8 @@ fn test_source_comments() {
         "<Exp(<Var(\"a\")@8..9 @ 2:6>)@8..9 @ 2:6>"
     );
 }
+
+#[test]
+fn test_misc() {
+    assert_to(r#"'\"'; //abc"#, r#"'\"';"#);
+}


### PR DESCRIPTION
This PR fixes a corner case in the relatively new comment parser logic (https://github.com/dfinity/vscode-motoko/issues/179). 
