### PR TITLE
Feature: Rustyline support.

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -33,6 +33,7 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 test-log = "0.2.11"
 dyn-clone = "1.0.9"
 candid = "0.8.4"
+rustyline = "7.0.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/crates/motoko/src/lib/vm_core.rs
+++ b/crates/motoko/src/lib/vm_core.rs
@@ -820,6 +820,11 @@ impl Core {
         self.run(&Limits::none())
     }
 
+    pub fn eval_str(&mut self, input: &str) -> Result<Value_, Interruption> {
+        let prog = crate::check::parse(input)?;
+        self.eval_prog(prog)
+    }
+
     /// Evaluate a new program fragment, assuming agent is idle.
     ///
     /// The block may refer to variables

--- a/crates/motoko/src/lib/vm_def.rs
+++ b/crates/motoko/src/lib/vm_def.rs
@@ -194,7 +194,7 @@ pub mod def {
     use crate::ast::{DecField, DecFields};
 
     pub fn import<A: Active>(active: &mut A, path: &str) -> Result<ModuleDef, Interruption> {
-        let path0 = path.clone(); // for log.
+        let path0 = path; // for log.
         let path = format!("{}", &path[1..path.len() - 1]);
         let (package_name, local_path) = if path == "mo:⛔" || path == "mo:prim" {
             (Some("⛔".to_string()), "lib".to_string())

--- a/crates/motoko/src/lib/vm_types.rs
+++ b/crates/motoko/src/lib/vm_types.rs
@@ -784,6 +784,7 @@ pub enum Interruption {
     NoMatchingCase,
     #[cfg(feature = "parser")]
     SyntaxError(SyntaxError),
+    SyntaxErrorCode(SyntaxErrorCode),
     ValueError(ValueError),
     EvalInitError(EvalInitError),
     UnboundIdentifer(Id),
@@ -832,6 +833,12 @@ impl Interruption {
 impl From<SyntaxError> for Interruption {
     fn from(err: SyntaxError) -> Self {
         Interruption::SyntaxError(err)
+    }
+}
+
+impl From<SyntaxErrorCode> for Interruption {
+    fn from(err: SyntaxErrorCode) -> Self {
+        Interruption::SyntaxErrorCode(err)
     }
 }
 


### PR DESCRIPTION
Adds a simple `repl` command using `rustyline` under the hood (similar to `ic-repl`).