### PR TITLE
Add `->` token to lexer

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.27"
+version = "0.0.28"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -32,8 +32,8 @@ serde_path_to_error = { version = "0.1.8", optional = true }
 # serde_with = "2.0.1"
 test-log = "0.2.11"
 dyn-clone = "1.0.9"
-candid = "0.8.4"
-rustyline = "7.0.0"
+candid = "0.8"
+rustyline = { version = "7.0.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.4.0"
@@ -44,15 +44,15 @@ lalrpop = "0.19.7"
 [lib]
 name = "motoko"
 path = "src/lib/mod.rs"
-test = true            # Is tested by default.
-doctest = true         # Documentation examples are tested by default.
-bench = true           # Is benchmarked by default.
-doc = true             # Is documented by default.
-plugin = false         # Used as a compiler plugin (deprecated).
-harness = true         # Use libtest harness.
-edition = "2018"       # The edition of the target.
-crate-type = ["lib"]   # The crate types to generate.
-required-features = [] # Features required to build this target (N/A for lib).
+test = true             # Is tested by default.
+doctest = true          # Documentation examples are tested by default.
+bench = true            # Is benchmarked by default.
+doc = true              # Is documented by default.
+plugin = false          # Used as a compiler plugin (deprecated).
+harness = true          # Use libtest harness.
+edition = "2018"        # The edition of the target.
+crate-type = ["lib"]    # The crate types to generate.
+required-features = []  # Features required to build this target (N/A for lib).
 
 [[bin]]
 name = "mo-rs"
@@ -64,7 +64,7 @@ default = ["parser", "to-motoko"]
 #default = []
 reflection = ["value-reflection", "core-reflection"]
 
-exe = []
+exe = ["rustyline"]
 serde-paths = ["serde_path_to_error"]
 parser = []
 to-motoko = []

--- a/crates/motoko/src/lib/lexer_types.rs
+++ b/crates/motoko/src/lib/lexer_types.rs
@@ -55,6 +55,7 @@ pub enum Token {
     #[token("!", data)]
     #[token("^", data)]
     #[token("<:", data)]
+    #[regex("->", data)]
     #[regex(r"(\+|-|\*\*?|/|&|<?\|>?)%?=?", data)]
     #[regex(r"([\^]|<<>?|( |<)>>|#)(|=)", data)]
     #[regex(r"[:%!=<>]=", data)]

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.27"
+version = "0.0.28"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 # TODO: set this up as a "workspace dependency"? 
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
-motoko = { path = "../motoko", version = "0.0.27", default-features = false, features = ["parser"] }
+motoko = { path = "../motoko", version = "0.0.28", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"


### PR DESCRIPTION
Includes the missing `->` token in the lexer (used by [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko)).