### PR TITLE
Add new keywords

### DIFF
--- a/crates/motoko/Cargo.toml
+++ b/crates/motoko/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko"
-version = "0.0.31"
+version = "0.0.32"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 build = "build.rs"

--- a/crates/motoko/src/lib/lexer.rs
+++ b/crates/motoko/src/lib/lexer.rs
@@ -58,6 +58,10 @@ pub const KEYWORDS: &[&str] = &[
     "persistent",
     "transient",
     "do",
+    "implicit",
+    "weak",
+    "mixin",
+    "include",
 ];
 
 pub fn is_keyword(ident: &str) -> bool {

--- a/crates/motoko_proc_macro/Cargo.toml
+++ b/crates/motoko_proc_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motoko_proc_macro"
-version = "0.0.31"
+version = "0.0.32"
 authors = ["Matthew Hammer", "Ryan Vandersmith"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 # TODO: set this up as a "workspace dependency"? 
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
-motoko = { path = "../motoko", version = "0.0.31", default-features = false, features = ["parser"] }
+motoko = { path = "../motoko", version = "0.0.32", default-features = false, features = ["parser"] }
 syn = "1.0.100"
 quote = "1.0.21"
 proc-macro2 = "1.0.44"


### PR DESCRIPTION
Adds `implicit`, `weak`, `mixin`, and `include` to the list of Motoko keywords.