### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,24 +6,24 @@ jobs:
     name: run benchmark
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       with:
         fetch-depth: 0
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         profile: minimal
         toolchain: stable
         override: true
     - name: Cache cargo build
-      uses: actions/cache@v2
+      uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
       with:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
           target
         key: ${{ runner.os }}-bench-${{ hashFiles('**/Cargo.lock') }}
-    - uses: boa-dev/criterion-compare-action@master
+    - uses: boa-dev/criterion-compare-action@16002f0a9fb0b371d92ab13cec5f4978815200bd # master
       with:
         cwd: crates/motoko
         benchName: benchmark

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -14,7 +14,7 @@ jobs:
     name: license-check:required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868 # v1.6.3
         with:
           command: check bans licenses sources

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
       with:
         toolchain: nightly
         override: true


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `actions-rs/toolchain@v1` -> `actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7`
  - Version: v1.0.7 | Latest: v1.0.6 | Release age: 2208d
  - Commit: https://github.com/actions-rs/toolchain/commit/16499b5e05bf2e26879000db0c1d13f7e13fa3af

- `actions/cache@v2` -> `actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2`
  - Version: v2 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/8492260343ad570701412c2f464a5877dc76bace

- `boa-dev/criterion-compare-action@master` -> `boa-dev/criterion-compare-action@16002f0a9fb0b371d92ab13cec5f4978815200bd # master`
  - Version: master | Latest: v3.2.4 | Release age: 1264d
  - Commit: https://github.com/boa-dev/criterion-compare-action/commit/16002f0a9fb0b371d92ab13cec5f4978815200bd

- `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0`
  - Version: v3.6.0 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744

- `EmbarkStudios/cargo-deny-action@v1` -> `EmbarkStudios/cargo-deny-action@3f4a782664881cf5725d0ffd23969fcce89fd868 # v1.6.3`
  - Version: v1.6.3 | Latest: v2.0.16 | Release age: 92d
  - Commit: https://github.com/EmbarkStudios/cargo-deny-action/commit/3f4a782664881cf5725d0ffd23969fcce89fd868
  - Warnings: Latest release v2.0.16 is only 0 day(s) old (< 7 days). Using previous safe release.


### Files modified

- `.github/workflows/bench.yml`
- `.github/workflows/license.yml`
- `.github/workflows/rust.yml`

### Security warnings

- Latest release v2.0.16 is only 0 day(s) old (< 7 days). Using previous safe release.